### PR TITLE
spirit-tracks: added reset clause to dynamic flags

### DIFF
--- a/worlds/tloz_st/data/Items.py
+++ b/worlds/tloz_st/data/Items.py
@@ -144,7 +144,7 @@ ITEMS_DATA = {
         'incremental': True,
         'size': 2
     },
-        "Sword Beam Swordsman's Scroll": {
+    "Sword Beam Swordsman's Scroll": {
         'classification': ItemClassification.useful,
         'address': 0x265322,
         'value': 0x0010,


### PR DESCRIPTION
Updates dynamic flags system to same latest version as Phantom Hourglass
- Adds `"reset_flags"` argument to dynamic flags dictionary
- Adds support for doing other stuff with the same conditions system, with the method `has_dynamic_requirements` in client. 
  - In ph I'm using it for dynamic entrances, and i suspect something similar will be necessary in st to prevent link from boarding a train where there are no tracks.

## Syntax example
```python
DYNAMIC_FLAGS = {
    # Treasure Maps don't spawn if you have them in your inventory, remove from inventory on scenes with maps, and give 
    # them back on the next scene
    "Astrid's Basement Treasure Map": {
        "on_scenes": [0xD14],  # Inventory flag for treasure map 3
        "not_has_locations": ["Isle of Ember Astrid's Basement Dig"],
        "unset_if_true": [(0x1BA651, 0x20)],
        "reset_flags": ["RESET Astrid's Basement Treasure Map"]  # New reset argument
    },
    "RESET Astrid's Basement Treasure Map": {
        # "on_scenes": [0xD0A],  # legacy system reset on adjacent scenes, but that breaks with entrance rando or warp to start
        "has_items": [("Treasure Map #3 (Gusts SW)", 1)],
        "set_if_true": [(0x1BA651, 0x20)]
    },
}
```
