### PR TITLE
Develop bugfixes carrot v7.3

### DIFF
--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -917,6 +917,12 @@ class SpiritTracksClient(DSZeldaClient):
                 await ctx.send_death(ctx.player_names[ctx.slot] + message)
                 self.last_deathlink = ctx.last_death_link
 
+    async def get_item_read(self, ctx, item_name) -> int:
+        if item_name == "Red Potion":
+            return await STAddr.all_potions.read(ctx)
+
+        return await super().get_item_read(ctx, item_name)
+
     async def process_post_receive(self, ctx):
         if not self.delay_pickup:
             await self.update_treasure_tracker(ctx, "post_receive")  # always update treasure tracker, lots of random treasures on ground!

--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -793,20 +793,12 @@ class SpiritTracksClient(DSZeldaClient):
             await self.update_treasure_tracker(ctx, "no_loc")
             return
 
-        if location is not None and "goal" in location:
-            # Finished game?
-            goal = ctx.slot_data.get("goal")
-            if goal == 0 and location.get("region_id") == "tos 3f rail map":
-                await self.store_event(ctx, "GOAL: Reach ToS 3F")
-                self.has_goal_location = True
-            if goal == 1 and location.get("region_id") == "tos 7f rail map":
-                await self.store_event(ctx, "GOAL: Reach ToS 7F")
-                self.has_goal_location = True
-            if goal == 2 and location.get("region_id") == "wt stagnox":
-                await self.store_event(ctx, "GOAL: Defeat Stagnox")
-                self.has_goal_location = True
-            if goal == 3 and location.get("region_id") == "bt fraaz":
-                await self.store_event(ctx, "GOAL: Defeat Fraaz")
+        if "goal" in location:
+            from .data.Entrances import goal_event_lookup
+            goal = ctx.slot_data.get("goal", -1)
+            loc_goal = location["goal"]
+            if goal_event_lookup[goal] == loc_goal:
+                await self.store_event(ctx, loc_goal)
                 self.has_goal_location = True
 
         if "rabbit" in location and "address" in location:

--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -572,11 +572,6 @@ class SpiritTracksClient(DSZeldaClient):
                 print(f"Opening boss door for {hex(self.current_scene)}")
                 await data["door"].overwrite(ctx, 3)
 
-        if self.current_scene == 0x2B00 and item_name == "Song of Discovery":
-            await STAddr.songs.unset_bits(ctx, 0x10)
-        if self.current_scene == 0x2C00 and item_name == "Song of Birds":
-            await STAddr.songs.unset_bits(ctx, 0x4)
-
     async def process_on_room_load(self, ctx, current_scene, read_result: dict):
         await self.update_treasure_tracker(ctx, "room_load")
         await self.update_potion_tracker(ctx, "room_load")

--- a/worlds/tloz_st/Logic.py
+++ b/worlds/tloz_st/Logic.py
@@ -464,7 +464,7 @@ def make_overworld_logic(player: int, origin_name: str, options: SpiritTracksOpt
         # ========== Island Sanctuary =============
         ["ocean realm", "ocs", False, None],
         ["ocs", "ocs north", False, lambda state: st_has_boomerang(state, player)
-                                                  or (st_has_birds_song(state, player) and st_has_whip(state, player) and options.logic.value)], # Spreadsheet shows Whirlwind needed too,
+                                                  or (st_has_birds_song(state, player) and st_has_whip(state, player) and st_option_hard_logic(state, player))], # Spreadsheet shows Whirlwind needed too,
                                                                                   # but not sure why looking at walkthrough
                                                                                   # probably wants you to whirlwind a bomb in the cave, but you can make the throw.
         ["ocs north", "ocs stamp station", False, lambda state: st_has_stamp_book(state, player)
@@ -476,7 +476,7 @@ def make_overworld_logic(player: int, origin_name: str, options: SpiritTracksOpt
             if options.randomize_passengers == "no_passengers" else
         ["ocs carben", "ocs song", False, lambda state: st_has_spirit_flute(state, player)
                                                         and (st_has_boomerang(state, player)
-                                                             or (st_has_birds_song(state, player) and st_has_whip(state, player) and options.logic.value))],
+                                                             or (st_has_birds_song(state, player) and st_has_whip(state, player) and st_option_hard_logic(state, player)))],
         ["ocs", "ocs carben", False, lambda state: st_has_passenger(state, player, "Carben", "_carben")
                                                    and (options.randomize_passengers.value != 1
                                                         or st_has_sword(state, player)  # Fight off the blins

--- a/worlds/tloz_st/Logic.py
+++ b/worlds/tloz_st/Logic.py
@@ -463,7 +463,8 @@ def make_overworld_logic(player: int, origin_name: str, options: SpiritTracksOpt
 
         # ========== Island Sanctuary =============
         ["ocean realm", "ocs", False, None],
-        ["ocs", "ocs north", False, lambda state: st_has_boomerang(state, player)], # Spreadsheet shows Whirlwind needed too,
+        ["ocs", "ocs north", False, lambda state: st_has_boomerang(state, player)
+                                                  or (st_has_birds_song(state, player) and st_has_whip(state, player) and options.logic.value)], # Spreadsheet shows Whirlwind needed too,
                                                                                   # but not sure why looking at walkthrough
                                                                                   # probably wants you to whirlwind a bomb in the cave, but you can make the throw.
         ["ocs north", "ocs stamp station", False, lambda state: st_has_stamp_book(state, player)
@@ -473,7 +474,9 @@ def make_overworld_logic(player: int, origin_name: str, options: SpiritTracksOpt
         ["ocs north", "ocs nw chest", False, lambda state: st_hard_birds(state, player)],
         ["ocs north", "ocs song", False, lambda state: st_has_spirit_flute(state, player)]
             if options.randomize_passengers == "no_passengers" else
-        ["ocs carben", "ocs song", False, lambda state: st_has_spirit_flute(state, player)],
+        ["ocs carben", "ocs song", False, lambda state: st_has_spirit_flute(state, player)
+                                                        and (st_has_boomerang(state, player)
+                                                             or (st_has_birds_song(state, player) and st_has_whip(state, player) and options.logic.value))],
         ["ocs", "ocs carben", False, lambda state: st_has_passenger(state, player, "Carben", "_carben")
                                                    and (options.randomize_passengers.value != 1
                                                         or st_has_sword(state, player)  # Fight off the blins

--- a/worlds/tloz_st/Logic.py
+++ b/worlds/tloz_st/Logic.py
@@ -196,7 +196,7 @@ def make_overworld_logic(player: int, origin_name: str, options: SpiritTracksOpt
 
         ["tos 14f east", "tos 14f phantom", False, lambda state:
          st_can_possess_phantoms(state, player, 4) | (st_vanilla_tears(state, player) & st_has_whip(state, player))],
-        ["tos 14f west", "tos 15f", False, None],
+        ["tos 14f west", "tos 15f", False, lambda state: st_has_whip(state, player)],
         ["tos 15f", "tos 16f", False, lambda state: st_tos_15f_glitched(state, player)],
         ["tos 16f", "tos 16f bombs", False, lambda state: st_has_bombs(state, player)],
         ["tos 16f", "event_17f", False, None],
@@ -225,6 +225,7 @@ def make_overworld_logic(player: int, origin_name: str, options: SpiritTracksOpt
         ["tos 19f center", "tos 20f", False, lambda state: st_has_small_keys(state, player, "ToS 5", 2)],
 
         ["tos 20f", "tos 19f center 2", False, lambda state: st_has_bow(state, player) & st_can_rotate_repeater(state, player)],
+        ["tos 20f", "tos 19f center chest", False, lambda state: st_has_bow(state, player)],
         ["tos 20f", "tos 22f", False, lambda state: st_has_bow(state, player) and st_can_rotate_repeater(state, player) and st_has_whip(state, player)],
         ["tos 22f", "tos 21f bombs", False, lambda state: st_has_bombs(state, player)],
         ["tos 22f", "tos staven", False, lambda state: st_has_sword(state, player) and (st_has_boss_key(state, player, "ToS 5") or options.randomize_boss_keys == "vanilla" or state.multiworld.worlds[player].exclude_tos_5)],
@@ -577,7 +578,7 @@ def make_overworld_logic(player: int, origin_name: str, options: SpiritTracksOpt
         ["fire source", "s mountain temple rabbit", False, lambda state: st_has_net(state, player)],
         ["mountain temple tracks", "s mountain temple rabbit", False, lambda state: st_has_net(state, player)],
 
-        ["fire realm", "forest cave tracks", False, lambda state: st_has_misc_tracks(state, player,"W Forest Realm") and st_has_portal(state, player, "Forest Cave to Goron Village", False)],
+        ["fire realm", "forest cave tracks", False, lambda state: st_has_misc_tracks(state, player,"Forest Realm SW Cave") and st_has_portal(state, player, "Forest Cave to Goron Village", False)],
         ["forest cave tracks", "fire realm", False, lambda state: st_has_glyph(state, player, "Fire") and st_has_portal(state, player,"Forest Cave to Goron Village",True)],
         ["mountain temple tracks", "icyspring tracks", False, lambda state: st_has_misc_tracks(state, player,"N Icy Spring") and st_has_portal(state, player,"Icy Spring to Mountain Temple",False)],
         ["icyspring tracks", "mountain temple tracks", False, lambda state: st_has_temple_tracks(state, player, "Mountain") and st_has_portal(state, player,"Icy Spring to Mountain Temple",True)],
@@ -614,7 +615,9 @@ def make_overworld_logic(player: int, origin_name: str, options: SpiritTracksOpt
         ["fire realm", "gtr", False, lambda state: st_has_cannon(state, player) and state.has("_goron_ice", player) and st_has_rupees(state, player, 50)],
 
         # Mountain Temple
-        ["mountain temple tracks", "mtt", False, lambda state: state.has("Mountain Temple Snurglar Key", player, 3) or state.has("Snurglar Keyring", player)],
+        ["mountain temple tracks", "mountain temple door", False, None],
+        ["fire source", "mountain temple door", False, None],
+        ["mountain temple door", "mtt", False, lambda state: state.has("Mountain Temple Snurglar Key", player, 3) or state.has("Snurglar Keyring", player)],
         ["mtt", "mtt song statue", False, lambda state: st_has_spirit_flute(state, player)],
         ["mtt", "mtt left", False, lambda state: st_has_damage(state, player)],
         ["mtt left", "mtt right", False, lambda state: st_has_range(state, player) or st_has_bombs(state, player)],

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -542,6 +542,7 @@ class SpiritTracksWorld(WorldParent):
                         return False
                 return True
         if location_name == "Goron Village Get Wagon":
+            print(f"Wagon check: {self.options.randomize_cargo.value}")
             return self.options.randomize_cargo.value
         return False
 

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -542,7 +542,6 @@ class SpiritTracksWorld(WorldParent):
                         return False
                 return True
         if location_name == "Goron Village Get Wagon":
-            print(f"Wagon check: {self.options.randomize_cargo.value}")
             return self.options.randomize_cargo.value
         return False
 

--- a/worlds/tloz_st/data/Addresses.py
+++ b/worlds/tloz_st/data/Addresses.py
@@ -98,6 +98,7 @@ class STAddr:
     
     potion_0 = Address(0x265334)
     potion_1 = Address(0x265335)
+    all_potions = Address(0x265334, size=2)
     
     rail_restorations = Address(0x2653B0)
     tracks_0 = Address(0x2653B4)

--- a/worlds/tloz_st/data/DynamicFlags.py
+++ b/worlds/tloz_st/data/DynamicFlags.py
@@ -1078,7 +1078,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
     },
     "Reset linebeck regal ring stuff in cave": {
         "on_scenes": [0x3702],
-        "not_has_locations": ["Trading Post Burried Chest"],
+        "not_has_locations": ["Trading Post Buried Chest"],
         "unset_if_true": [(STAddr.adv_flags_3e, 0x10)]
     },
     "Bring Kenzo to TP": {

--- a/worlds/tloz_st/data/DynamicFlags.py
+++ b/worlds/tloz_st/data/DynamicFlags.py
@@ -1620,7 +1620,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
     },
     "Papuzia allow dovok cs vanilla passengers": {
         "on_scenes": [0x2C00],
-        "set_if_true": [(STAddr.adv_flags_35, 0x20), (STAddr.adv_flags_9, 0x10)],
+        "set_if_true": [(STAddr.adv_flags_35, 0x20), (STAddr.adv_flags_9, 0x30)],
         "has_slot_data": [("randomize_passengers", 1)],
         "not_has_locations": ["Papuzia Village Orca's Force Gem"],
         "check_bits": [(STAddr.adv_flags_36, 0x4)],
@@ -1628,7 +1628,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
     },
     "Papuzia allow wadatsumi cs vanilla passengers": {
         "on_scenes": [0x2C00],
-        "set_if_true": [(STAddr.adv_flags_9, 0x10)],
+        "set_if_true": [(STAddr.adv_flags_9, 0x30)],
         "unset_if_true": [(STAddr.adv_flags_34, 0x80)],
         "has_slot_data": [("randomize_passengers", 1)],
         "not_has_locations": ["Papuzia Village Wadatsumi's Force Gem"],
@@ -1637,13 +1637,13 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
     },
     "RESET wadatsumi complicated vanilla passengers": {
         "not_has_locations": ["Island Sanctuary Carben's Force Gem"],
-        "unset_if_true": [(STAddr.adv_flags_9, 0x10)]
+        "unset_if_true": [(STAddr.adv_flags_9, 0x30)]
         # Papuzia crashes if you've not removed carben before Orca asks for a husband,
         # and you need that orca flag for the dovok leaving the train CS
     },
     "RESET dovok complicated vanilla passengers": {
         "not_has_locations": ["Island Sanctuary Carben's Force Gem"],
-        "unset_if_true": [(STAddr.adv_flags_35, 0x20), (STAddr.adv_flags_9, 0x10)]
+        "unset_if_true": [(STAddr.adv_flags_35, 0x20), (STAddr.adv_flags_9, 0x30)]
         # Papuzia crashes if you've not removed carben before Orca asks for a husband,
         # and you need that orca flag for the dovok leaving the train CS
     },
@@ -1652,7 +1652,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "has_slot_data": [("randomize_passengers", [2, 3])],
         "has_items": [("Passenger: Dovok", 1)],
         "not_has_locations": ["Papuzia Village Orca's Force Gem"],
-        "set_if_true": [(STAddr.adv_flags_36, 0x4), (STAddr.adv_flags_35, 0x20), (STAddr.adv_flags_9, 0x10)],
+        "set_if_true": [(STAddr.adv_flags_36, 0x4), (STAddr.adv_flags_35, 0x20), (STAddr.adv_flags_9, 0x30)],
         "overwrite_if_true": [(STAddr.passenger_goal, 0x2c),
                               (STAddr.passenger_tag_0, 0x464F4D52),
                               (STAddr.has_passenger_0, 0)],
@@ -1660,7 +1660,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
     },
     "RESET dovok complicated": {
         "not_has_locations": ["Papuzia Village Pick Up Carben"],
-        "unset_if_true": [(STAddr.adv_flags_35, 0x20), (STAddr.adv_flags_9, 0x10)]
+        "unset_if_true": [(STAddr.adv_flags_35, 0x20), (STAddr.adv_flags_9, 0x30)]
         # Papuzia crashes if you've not removed carben before Orca asks for a husband,
         # and you need that orca flag for the dovok leaving the train CS
     },
@@ -1671,11 +1671,35 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "unset_if_true": [(STAddr.adv_flags_14, 0x20)],
         "has_items": [("Passenger: Dovok", 0)],
     },
-    "Papuzia prevent carben crash passengers": {
+    "Papuzia prevent carben crash neither": {
         "on_scenes": [0x2c00],
         "not_has_locations": ["Papuzia Village Pick Up Carben"],
         "has_slot_data": [("randomize_passengers", [2, 3])],
         "unset_if_true": [(STAddr.adv_flags_9, 0x30)],
+        "has_items": [("Passenger: Dovok", 0), ("Passenger: Wadatsumi", 0)],
+    },
+    "Papuzia prevent carben crash post dovok": {
+        "on_scenes": [0x2c00],
+        "not_has_locations": ["Papuzia Village Pick Up Carben"],
+        "has_slot_data": [("randomize_passengers", [2, 3])],
+        "unset_if_true": [(STAddr.adv_flags_9, 0x30)],
+        "has_items": [("Passenger: Wadatsumi", 0)],
+        "has_locations": ["Papuzia Village Orca's Force Gem"]
+    },
+    "Papuzia prevent carben post wadatsumi": {
+        "on_scenes": [0x2c00],
+        "not_has_locations": ["Papuzia Village Pick Up Carben"],
+        "has_slot_data": [("randomize_passengers", [2, 3])],
+        "unset_if_true": [(STAddr.adv_flags_9, 0x30)],
+        "has_items": [("Passenger: Dovok", 0)],
+        "has_locations": ["Papuzia Village Wadatsumi's Force Gem"]
+    },
+    "Papuzia prevent carben post both": {
+        "on_scenes": [0x2c00],
+        "not_has_locations": ["Papuzia Village Pick Up Carben"],
+        "has_slot_data": [("randomize_passengers", [2, 3])],
+        "unset_if_true": [(STAddr.adv_flags_9, 0x30)],
+        "has_locations": ["Papuzia Village Wadatsumi's Force Gem", "Papuzia Village Orca's Force Gem"]
     },
     "Papuzia prevent carben crash post carben": {
         "on_scenes": [0x2c00],
@@ -1774,6 +1798,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "has_items": [("Passenger: Carben", 1)],
         "not_has_locations": ["Island Sanctuary Carben's Force Gem"],
         "set_if_true": [(STAddr.adv_flags_9, 0x10)],
+        "unset_if_true": [(STAddr.adv_flags_9, 0x20)],  # Prevent invisible carben
         "overwrite_if_true": [(STAddr.passenger_goal, 0x32),
                               (STAddr.passenger_tag_0, 0x53595741),
                               (STAddr.has_passenger_0, 0)],
@@ -1854,7 +1879,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "has_slot_data": [("randomize_passengers", [2, 3])],
         "has_items": [("Passenger: Wadatsumi", 1)],
         "check_bits": [(STAddr.adv_flags_e, 0x40, "not")], #Check for Force Gem obtained, and don't trigger if it was done already
-        "set_if_true": [(STAddr.adv_flags_34, 0x40), (STAddr.adv_flags_9, 0x10)], #Set Wadatsumi on train
+        "set_if_true": [(STAddr.adv_flags_34, 0x40), (STAddr.adv_flags_9, 0x30)], #Set Wadatsumi on train
         "unset_if_true": [(STAddr.adv_flags_34, 0x80)],
         "overwrite_if_true": [(STAddr.passenger_goal, 0x2C),
                               (STAddr.passenger_tag_0, 0x57414D41),
@@ -2120,12 +2145,21 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "not_has_locations": ["Papuzia Village Song Statue"],
         "has_items": [("Song of Discovery", 1)],
         "unset_if_true": [(STAddr.songs, 0x4)],
-        "set_if_true": [(STAddr.adv_flags_a, 0xA0)],
+        "set_if_true": [(STAddr.adv_flags_a, 0xA0)]
+    },
+    "Papuzia default reset SoB": {
+        "on_scenes": [0x2c00],
         "reset_flags": ["RESET SoB"]
     },
     "RESET SoB": {
         "has_items": [("Song of Birds", 1)],
         "set_if_true": [(STAddr.songs, 0x4)],
+    },
+    "Papuzia allow song of birds": {
+        "on_scenes": [0x2c00],
+        "not_has_locations": ["Papuzia Village Song Statue"],
+        "has_items": [("Song of Birds", 1)],
+        "set_if_true": [(STAddr.songs, 4)],
     },
     "Papuzia can buy vessel": {
         "on_scenes": [0x2c04],

--- a/worlds/tloz_st/data/DynamicFlags.py
+++ b/worlds/tloz_st/data/DynamicFlags.py
@@ -1154,11 +1154,11 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "not_has_locations": ["Trading Post Pick Up Kenzo"],
         "has_slot_data": [("randomize_passengers", 3)],
         "check_bits": [(STAddr.adv_flags_3c, 0x10)],
-        "unset_if_true": [(STAddr.adv_flags_3c, 0x10)],
+        "unset_if_true": [(STAddr.adv_flags_3c, 0x50)],
         "reset_flags": ["Kenzo av yes"]
     },
     "Kenzo av yes": {
-        "set_if_true": [(STAddr.adv_flags_3c, 0x10)],
+        "set_if_true": [(STAddr.adv_flags_3c, 0x50)],
     },
     "Bring Goron to CT": {
         "on_scenes": [0x2900],
@@ -1264,7 +1264,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
     },
     "Backup unset goron geyser": {
         "on_scenes": [0x2e00],
-        "has_slot_data": ["randomize_cargo", [1, 2, 3]],
+        "has_slot_data": [("randomize_cargo", [1, 2, 3])],
         "check_bits": [(STAddr.adv_flags_59, 0x4, "not")],
         "unset_if_true": [(STAddr.adv_flags_1f, 0x80)],
     },
@@ -2282,7 +2282,8 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
     "GV add snow goron snow glyph vanilla": {
         "on_scenes": [0x2E00],
         "has_groups": ["Tracks: Snow Glyph"],
-        "check_bits": [(STAddr.adv_flags_38, 2, "not")],
+        "check_bits": [(STAddr.adv_flags_59, 0x4)],
+        "unset_if_true": [(STAddr.adv_flags_38, 2)],
         "has_slot_data": [("randomize_passengers", 1)],
     },
     "ToS Force spawn train": {

--- a/worlds/tloz_st/data/Items.py
+++ b/worlds/tloz_st/data/Items.py
@@ -174,7 +174,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'address': STAddr.adv_flags_25,
         'value': 0x02,
         'item_groups': ["Equipment"],
-        "model": "Stamp Book"
+        "model": "Stamp Book",
+        "blocked_scenes": [0x2f0a]
     },
     "Dummy Bow": {
         'classification': ItemClassification.filler,
@@ -188,35 +189,40 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'address': STAddr.songs,
         'value': 0x01,
         'item_groups': ["Songs"],
-        "model": "SoA"
+        "model": "SoA",
+        "blocked_scenes": [0x3000]
     },
     "Song of Healing": {
         'classification': ItemClassification.useful,
         'address': STAddr.songs,
         'value': 0x02,
         'item_groups': ["Songs"],
-        "model": "SoH"
+        "model": "SoH",
+        "blocked_scenes": [0x190A, 0x1B0A, 0x1C0A],
     },
     "Song of Birds": {
         'classification': ItemClassification.progression,
         'address': STAddr.songs,
         'value': 0x04,
         'item_groups': ["Songs"],
-        "model": "SoB"
+        "model": "SoB",
+        "blocked_scenes": [0x2C00]
     },
     "Song of Light": {
         'classification': ItemClassification.progression,
         'address': STAddr.songs,
         'value': 0x08,
         'item_groups': ["Songs"],
-        "model": "SoL"
+        "model": "SoL",
+        "blocked_scenes": [0x3700]
     },
     "Song of Discovery": {
         'classification': ItemClassification.progression,
         'address': STAddr.songs,
         'value': 0x10,
         'item_groups': ["Songs"],
-        "model": "SoD"
+        "model": "SoD",
+        "blocked_scenes": [0x2B00]
     },
 
     # ============= Upgrades =============

--- a/worlds/tloz_st/data/Locations.py
+++ b/worlds/tloz_st/data/Locations.py
@@ -253,7 +253,7 @@ LOCATIONS_DATA = {
         "z_max": -35000,
         "location_groups": ["Hyrule Castle"],
     },
-    "Hyrule Castle 1F Spirit Flute": {
+    "Hyrule Castle 3F Spirit Flute": {
         "region_id": "hyrule castle",
         "vanilla_item": "Spirit Flute",
         "stage_id": 0x28,
@@ -456,7 +456,7 @@ LOCATIONS_DATA = {
         "room_id": 4,
         "x_min": -35240,
         "x_max": -22990,
-        "z_min": 42350,
+        "z_min": 35000,
         "z_max": 52230,
         'dungeon': "ToS",
         "tos_section": 2
@@ -889,7 +889,7 @@ LOCATIONS_DATA = {
     },
     "ToS 22F Boss Key": {
         "vanilla_item": "Boss Key (ToS 5)",
-        "region_id": "tos 19f center 2",
+        "region_id": "tos 22f",
         'dungeon': "ToS",
         "tos_section": 5,
         "conditional": True,
@@ -2284,7 +2284,7 @@ LOCATIONS_DATA = {
         "room_id": 0x6,
         "region_id": "mtt left",
         "vanilla_item": "Small Key (Mountain Temple)",
-        "x_max": -55000,
+        "x_max": -50000,
         "z_min": -45000,
         "dungeon": "Mountain Temple"
     },

--- a/worlds/tloz_st/data/Locations.py
+++ b/worlds/tloz_st/data/Locations.py
@@ -43,7 +43,7 @@ LOCATIONS_DATA = {
         "location_groups": ["Outset Village"],
         "conditional": True
     },
-    "Ouset Beach Tree Burried Chest": {
+    "Outset Beach Tree Buried Chest": {
         "region_id": "outset village trees",
         "vanilla_item": ITEM_GROUPS["Uncommon Treasures"],
         "stage_id": 0x2F,
@@ -54,7 +54,7 @@ LOCATIONS_DATA = {
         "z_max": 33968,
         "location_groups": ["Outset Village"],
     },
-    "Outset Niko's House Tree Burried Chest": {
+    "Outset Niko's House Tree Buried Chest": {
         "region_id": "outset village trees",
         "vanilla_item": ITEM_GROUPS["Uncommon Treasures"],
         "stage_id": 0x2F,
@@ -1359,7 +1359,7 @@ LOCATIONS_DATA = {
         "z_max": -35679,
         "location_groups": ["Trading Post", "Song Statue"],
     },
-    "Trading Post Burried Chest": {
+    "Trading Post Buried Chest": {
         "region_id": "trading post chest",
         "vanilla_item": "Treasure: Regal Ring",
         "stage_id": 0x37,
@@ -1670,7 +1670,7 @@ LOCATIONS_DATA = {
     },
 
     # Bridge Worker's Home
-    "Bridge Worker's Home Burried Chest": {
+    "Bridge Worker's Home Buried Chest": {
         "region_id": "bridge workers chest",
         "vanilla_item": "Big Green Rupee (100)",
         "stage_id": 0x36,
@@ -2026,7 +2026,7 @@ LOCATIONS_DATA = {
     },
     # Lost at Sea Station
 
-    "Lost at Sea Burried Chest": {
+    "Lost at Sea Buried Chest": {
         "region_id": "las outside chest",
         "vanilla_item": ITEM_GROUPS["Rare Treasures"],
         "stage_id": 0x39,
@@ -2546,7 +2546,7 @@ LOCATIONS_DATA = {
         "conditional": True
     },
     # Dark Ore Mine
-    "Dark Ore Mine Burried Chest": {
+    "Dark Ore Mine Buried Chest": {
         "stage_id": 0x3D,
         "room_id": 0x1,
         "z_max": -15000,
@@ -2633,7 +2633,7 @@ LOCATIONS_DATA = {
         "region_id": "dt 1f n earthquake",
         "dungeon": "Desert Temple",
     },
-    "Desert Temple 1F N Burried Key": {
+    "Desert Temple 1F N Buried Key": {
         "stage_id": 0x1D,
         "room_id": 0x0,
         "x_max": 0,

--- a/worlds/tloz_st/data/Regions.py
+++ b/worlds/tloz_st/data/Regions.py
@@ -389,6 +389,7 @@ REGIONS = [
     "gorge tracks",
     "fire source",
     "mountain temple tracks",
+    "mountain temple door",
     "snurglars",
     "ends of the earth",
     "disorientation station",

--- a/worlds/tloz_st/test/bases.py
+++ b/worlds/tloz_st/test/bases.py
@@ -32,7 +32,7 @@ class TestGeneration(WorldTestBase):
         "excess_random_treasure": "nothing",
         "logic": "normal",
         "randomize_passengers": "randomize",
-        "randomize_cargo": "randomize",
+        "randomize_cargo": "no_cargo",
         "randomize_stamps": "randomize",
         "stamp_pack_sizes": 1,
         "randomize_minigames": "hard",

--- a/worlds/tloz_st/tracker/locations/overworld.json
+++ b/worlds/tloz_st/tracker/locations/overworld.json
@@ -3,8 +3,8 @@
     {"name": "Outset Clear Rocks"},
     {"name": "Outset Bee Tree"},
     {"name": "Outset Stamp Station"},
-    {"name": "Ouset Beach Tree Burried Chest"},
-    {"name": "Outset Niko's House Tree Burried Chest"},
+    {"name": "Outset Beach Tree Buried Chest"},
+    {"name": "Outset Niko's House Tree Buried Chest"},
     {"name": "Outset Pick Up Joe"},
     {"name": "Outset Ferrus Force Gem"},
     {"name": "Outset Deliver Cuccos"},
@@ -100,7 +100,7 @@
     {"name": "Trading Post Buy Shield"},
     {"name": "Trading Post Stamp Station"},
     {"name": "Trading Post Song Statue"},
-    {"name": "Trading Post Burried Chest"},
+    {"name": "Trading Post Buried Chest"},
     {"name": "Trading Post Deliver Dark Ore"}
   ], "map_locations":[{"map": "Overview", "x": 404, "y": 670}]},
   {"name": "Trading Post Events", "sections": [{"name": "EVENT: Give Regal Ring to Linebeck"}], "map_locations":[{"map": "Overview", "x": 420, "y": 670}]},
@@ -159,7 +159,7 @@
     {"name": "Slippery Station Champion Reward"}
   ], "map_locations":[{"map": "Overview", "x": 381, "y": 42}]},
   {"name": "Bridge Worker's", "sections": [
-    {"name": "Bridge Worker's Home Burried Chest"},
+    {"name": "Bridge Worker's Home Buried Chest"},
     {"name": "Bridge Worker's Home Pick Up Kenzo"}
   ], "map_locations":[{"map": "Overview", "x": 380, "y": 284}]},
 
@@ -300,7 +300,7 @@
         {"name": "Pirate Hideout Minigame 5000+"}
   ], "map_locations":[{"map": "Overview", "x": 592, "y": 564}]},
   {"name": "Lost at Sea Station", "sections": [
-    {"name": "Lost at Sea Burried Chest"},
+    {"name": "Lost at Sea Buried Chest"},
     {"name": "Lost at Sea Plain Phantom Chest"},
     {"name": "Lost at Sea Torch Phantom Chest"},
     {"name": "Lost at Sea Warp Phantom Chest"},
@@ -338,7 +338,7 @@
     {"name": "Dune Sanctuary Stamp Station"}
   ], "map_locations":[{"map": "Overview", "x": 692, "y": 428}]},
     {"name": "Dark Ore Mine", "sections": [
-      {"name": "Dark Ore Mine Burried Chest"},
+      {"name": "Dark Ore Mine Buried Chest"},
       {"name": "Dark Ore Mine Buy Ore"}
   ], "map_locations":[{"map": "Overview", "x": 956, "y": 116}]},
     {"name": "Desert Temple", "sections": [
@@ -350,7 +350,7 @@
           {"name": "Desert Temple 2F Left Chest"},
           {"name": "Desert Temple 2F Right Chest"},
           {"name": "Desert Temple 1F N Ergtorok Chest"},
-          {"name": "Desert Temple 1F N Burried Key"},
+          {"name": "Desert Temple 1F N Buried Key"},
           {"name": "Desert Temple B1 Stamp Station"},
           {"name": "Desert Temple B1 Near Boss Door Chest"},
           {"name": "Desert Temple B1 SW Stalfos Chest"},

--- a/worlds/tloz_st/tracker/locations/overworld.json
+++ b/worlds/tloz_st/tracker/locations/overworld.json
@@ -46,7 +46,7 @@
   {"name": "Hyrule Castle", "sections": [
     {"name": "Hyrule Castle Exterior NW Chest"},
     {"name": "Hyrule Castle 2F Indoors Chest"},
-    {"name": "Hyrule Castle 1F Spirit Flute"},
+    {"name": "Hyrule Castle 3F Spirit Flute"},
     {"name": "Hyrule Castle 1F Back Chest"},
     {"name": "Hyrule Castle 1F Sword Minigame 60 Points"},
     {"name": "Tunnel to ToS 1F Block Chest"},


### PR DESCRIPTION
- Add an attribute to items for “don’t immediately receive that item in theses rooms”, to prevent song statue crashes and more. Some cases were previously hard coded.
- added client implementation of goal location in dungeon cause apparently i forgot that.
- made sure carben restoration song logic didn't bypass boomerang requirements
- fixed typos on buried chests
- fixed typo on floor number for zelda's spirit flute location
- really worked through papuzia flags and crash states, and fixed the case family that was probably causing the crashes
- fixed invisible carben crash
- added north island sanctuary with song of birds to hard logic
- fixed ToS 4 missing whip in logic to reach 15F
- fixed some faulty logic in ToS 5
- added entering moutain temple from fire source to logic
- fixed the hitbox for mountain temple 2f left chest
- fixed goron village to se cave portal checking the wrong track for access
- fixed some faulty flags in goron village
- fixed anouki song of discovery chest sometimes not working (was not checking potion slot 2)
- tweaked some kenzo av flags