### PR TITLE
ST AP 7.4

### DIFF
--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -323,7 +323,7 @@ class SpiritTracksClient(DSZeldaClient):
                 print(f"\t\tCoords: {coords} reqs {coord_data}")
                 return all([
                     coord_data.get("x_max", 0xFFFFFFF) > coords['x'] > coord_data.get("x_min", -0xFFFFFFF),
-                    coord_data.get("y", 0) + 2000 > coords['y'] >= coord_data.get("y", 0),
+                    coord_data.get("y", coords['y']) + 2000 > coords['y'] >= coord_data.get("y", coords['y']),
                     coord_data.get("z_max", 0xFFFFFFF) > coords['z'] > coord_data.get("z_min", -0xFFFFFFF),
                 ])
 
@@ -834,6 +834,9 @@ class SpiritTracksClient(DSZeldaClient):
                 print("Opening ToS boss door after having key and getting boss key location")
                 await self.open_tos_boss_door(ctx, self.current_scene)
 
+        if self.snurglar_addr and location["name"] in LOCATION_GROUPS["Snurglars"]:
+            await self.snurglar_addr.unset_bits(ctx, 0xF)
+
     # fixes conflict with bizhawk_UT
     async def game_watcher(self, ctx: "BizHawkClientContext") -> None:
         await super().game_watcher(ctx)
@@ -1210,7 +1213,8 @@ class SpiritTracksClient(DSZeldaClient):
 
         if current_scene == 0x1c02 and self.current_entrance != 3:
             # Amazing that this works at all
-            await STAddr.mtt_b1_heatoise_trigger.overwrite(ctx, 70000)
+            pointer = await STAddr.mtt_b1_heatoise_trigger_pointer.read(ctx)
+            await Address.from_pointer(pointer+1384, 4).overwrite(ctx, 70000)
 
 
     @staticmethod

--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -519,15 +519,8 @@ class SpiritTracksClient(DSZeldaClient):
             await self.update_rabbit_count(ctx)
         if "Treasure:" in item_name:
             await self.update_treasure_tracker(ctx, "item_process")
-        if item_name == "Stamp Book" and self.current_scene == 0x2F0A:
-            await STAddr.adv_flags_25.unset_bits(ctx, 2)
         if item_name == "Bombs (Progressive)" and self.current_scene == 0x4503:
             await STAddr.adv_flags_22.unset_bits(ctx, 2)
-        if item_name in ["Forest Glyph", "Cannon",
-                         "Portal Unlock: Hyrule Castle to Anouki Village",
-                         "Portal Unlock: Trading Post to E Snow Realm"]:
-            print(f"Reloading dynamic entrances")
-            await self._set_dynamic_entrances(ctx, self.current_scene)  # allow escaping without reloading!
 
         if self.reload_on_item:
             print(f"Reloading dynamic entrances")
@@ -809,7 +802,7 @@ class SpiritTracksClient(DSZeldaClient):
             event_name = location["ut_connect"]
             await self.store_event(ctx, event_name)
 
-        if location["name"] in ["Outset Bee Tree", "Outset Clear Rocks"]:
+        if location["name"] in ["Outset Bee Tree", "Outset Clear Rfocks"]:
             self.reload_on_item = True
 
         if "Tear of Light" in location.get("vanilla_item", "") and ctx.slot_data["randomize_tears"] != -1:

--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -292,7 +292,7 @@ class SpiritTracksClient(DSZeldaClient):
         if self.current_stage < 0x13:
             coords = await read_multiple(ctx, STAddr.train_coords, True)
             train_coords = {l: c for c, l in zip(coords.values(), ['x', 'y', 'z'])}
-            print(f"Train coords: {train_coords}")
+            # print(f"Train coords: {train_coords}")
             return train_coords
         coords = await read_multiple(ctx, self.get_coord_address(multi=multi), signed=True)
         # print(f"Coords: {coords}")
@@ -301,6 +301,7 @@ class SpiritTracksClient(DSZeldaClient):
             "y": coords[STAddr.link_y],
             "z": coords[STAddr.link_z]
         }
+
 
     async def has_special_dynamic_requirements(self, ctx: "BizHawkClientContext", data) -> bool:
         def check_dungeon_reqs():
@@ -315,8 +316,24 @@ class SpiritTracksClient(DSZeldaClient):
                 return comp == data["dungeons"]
             return True
 
+        async def check_coords():
+            coord_data = data.get("coords", {})
+            if coord_data:
+                coords = await self.get_coords(ctx)
+                print(f"\t\tCoords: {coords} reqs {coord_data}")
+                return all([
+                    coord_data.get("x_max", 0xFFFFFFF) > coords['x'] > coord_data.get("x_min", -0xFFFFFFF),
+                    coord_data.get("y", 0) + 2000 > coords['y'] >= coord_data.get("y", 0),
+                    coord_data.get("z_max", 0xFFFFFFF) > coords['z'] > coord_data.get("z_min", -0xFFFFFFF),
+                ])
+
+            return True
+
         if not check_dungeon_reqs():
             print(f"\t{data['name']} does not have dungeon requirements")
+            return False
+        if not await check_coords():
+            print(f"\t{data['name']} does not have coordinate requirements")
             return False
         return True
 
@@ -1190,6 +1207,10 @@ class SpiritTracksClient(DSZeldaClient):
             elif ctx.slot_data["excess_random_treasure"] == 0:
                 treasure = ITEM_MODEL_LOOKUP["Nothing"].value
             await self.reset_treasure_models(ctx, treasure)
+
+        if current_scene == 0x1c02 and self.current_entrance != 3:
+            # Amazing that this works at all
+            await STAddr.mtt_b1_heatoise_trigger.overwrite(ctx, 70000)
 
 
     @staticmethod

--- a/worlds/tloz_st/Logic.py
+++ b/worlds/tloz_st/Logic.py
@@ -622,12 +622,7 @@ def make_overworld_logic(player: int, origin_name: str, options: SpiritTracksOpt
         ["mtt", "mtt left", False, lambda state: st_has_damage(state, player)],
         ["mtt left", "mtt right", False, lambda state: st_has_range(state, player) or st_has_bombs(state, player)],
         ["mtt left", "mtt 2f right", False, lambda state: st_has_range(state, player) or st_has_sword(state, player) or st_has_whip(state, player)],
-        ["mtt", "mtt center", False,
-            lambda state: st_has_small_keys(state, player, "Mountain Temple", 2) and (
-                    st_has_boomerang(state, player) or st_has_bombs(state, player) or (
-                        st_option_hard_logic(state, player) and (
-                            st_has_bow(state, player) or st_has_beam_sword(state, player) # Whip doesn't matter cause no checks until tortoises
-        )))],
+        ["mtt", "mtt center", False, lambda state: st_mtt_center(state, player)],
         ["mtt center", "mtt heatoise", False, lambda state: st_has_good_damage(state, player)],
         ["mtt heatoise", "mtt 1f ne", False, lambda state: st_has_bow(state, player)],
         ["mtt 1f ne", "mtt b1", False, lambda state: st_can_rotate_repeater(state, player)],

--- a/worlds/tloz_st/Logic.py
+++ b/worlds/tloz_st/Logic.py
@@ -629,7 +629,7 @@ def make_overworld_logic(player: int, origin_name: str, options: SpiritTracksOpt
         ["mtt b1", "mtt b2", False, lambda state: st_has_whip(state, player)],
         ["mtt b2", "mtt b1 arena", False, lambda state: st_has_boomerang(state, player)],
         ["mtt b1", "mtt b1 cart", False, lambda state: st_has_small_keys(state, player, "Mountain Temple", 3, 1)],
-        ["mtt b1 cart", "mtt b1 arena", False, None],
+        # ["mtt b1 cart", "mtt b1 arena", False, None],  # Removed!
         ["mtt b1 cart", "mtt stamp", False, lambda state: st_has_stamp_book(state, player)],
         ["mtt b1 cart", "mtt bk", False, lambda state: st_has_whirlwind(state, player)],
         ["mtt bk", "mtt boss", False, lambda state: options.randomize_boss_keys == "vanilla"],

--- a/worlds/tloz_st/Options.py
+++ b/worlds/tloz_st/Options.py
@@ -661,6 +661,15 @@ class SpiritTracksTrackGroupings(Choice):
     option_mixed_large = -2
     option_mixed_small = -3
 
+class SpiritTracksZeldaModelSwaps(Toggle):
+    """
+    Change the item models for items found belonging to other players to their nearest spirit-tracks equivalent.
+    Currently, all Zelda Games are implemented except the Oracle games.
+    Other copies of Spirit Tracks always swap their items.
+    """
+    display_name = "Multiworld Item Model Swaps"
+    default = 1
+
 @dataclass
 class SpiritTracksOptions(PerGameCommonOptions):
     # Accessibility
@@ -735,6 +744,7 @@ class SpiritTracksOptions(PerGameCommonOptions):
 
     # Cosmetic
     starting_train: SpiritTracksStartingTrain
+    multiworld_item_model_swaps: SpiritTracksZeldaModelSwaps
 
     # Generic
     start_inventory_from_pool: StartInventoryPool
@@ -802,7 +812,8 @@ st_option_groups = [
         SpiritTracksRabbitHints
     ]),
     OptionGroup("Cosmetic Options", [
-        SpiritTracksStartingTrain
+        SpiritTracksStartingTrain,
+        SpiritTracksZeldaModelSwaps
     ]),
     OptionGroup("Item & Location Options", [
         SpiritTracksRemoveItemsFromPool

--- a/worlds/tloz_st/Subclasses.py
+++ b/worlds/tloz_st/Subclasses.py
@@ -37,7 +37,7 @@ async def receive_tos_key(client: "SpiritTracksClient", ctx, item: "STItem", rii
     return res
 
 async def receive_tear_of_light(client: "SpiritTracksClient", ctx, item: "STItem", rii):
-    if client.current_stage == 0x13:
+    if client.current_stage == 0x13 and client.last_vanilla_item[-1] != item.name:  # avoid calcing tears when vanilla
         await client.set_tears(ctx)
 
     return []

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -1412,7 +1412,7 @@ class SpiritTracksWorld(WorldParent):
                 if ITEMS[item.name].model is not None:
                     location_models[loc_data['id']] = ITEM_MODEL_LOOKUP[ITEMS[item.name].model].offset
                     continue
-            elif item.game in all_lookups:
+            elif self.options.multiworld_item_model_swaps and item.game in all_lookups:
                 model = all_lookups[item.game].get(item.name, None)
                 if model is not None:
                     location_models[loc_data['id']] = model

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -64,6 +64,14 @@ class SpiritTracksWeb(WebWorld):
         link="setup/en",
         authors=["DayKat", "Carrotinator"]
     )
+    tricks_and_skips_en = Tutorial(
+        tutorial_name="Tricks and Skips",
+        description="A list of tricks and skips with their logic difficulty, and video links when available.",
+        language="English",
+        file_name="tricks_and_skips.md",
+        link="tricks_and_skips/en",
+        authors=["Carrotinator"]
+    )
 
     tutorials = [setup_en]
     option_groups = st_option_groups

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -1482,8 +1482,7 @@ class SpiritTracksWorld(WorldParent):
 
     def reconnect_found_entrances(self, key, stored_data):
         print(f"UT Tried to defer entrances! key {key}"
-              f" {stored_data}"
-              )
+              f" {stored_data}")
 
         if getattr(self.multiworld, "enforce_deferred_connections", "default") == "off":
             print(f"Don't defer entrances when off")
@@ -1496,7 +1495,11 @@ class SpiritTracksWorld(WorldParent):
                 pairing = self.ut_pairings.get(str(i), None)
                 # print(f"Pairing {pairing} {entrance_id_to_entrance[i].name}")
                 if pairing is not None:
-                    _exit: "Entrance" = self.get_entrance(entrance_id_to_entrance[i].name)
+                    exit_name = entrance_id_to_entrance[i].name
+                    _exit: "Entrance" = self.get_entrance(exit_name)
                     entrance_region: "Region" = self.get_region(entrance_id_to_region[pairing])
                     print(f"Connecting: {_exit} => {entrance_region} | {i}: {pairing}")
                     _exit.connect(entrance_region)
+
+                    if exit_name == "EVENT: Bring Ice to Kagoron":
+                        self.get_region("goron village").connect(self.get_region("goron ice"))

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -101,7 +101,7 @@ class SpiritTracksWorld(WorldParent):
     options_dataclass = SpiritTracksOptions
     options: SpiritTracksOptions
     settings: ClassVar[SpiritTracksSettings]
-    required_client_version = (0, 6, 1)
+    required_client_version = (0, 6, 3)
     web = SpiritTracksWeb()
     topology_present = True
 
@@ -466,7 +466,7 @@ class SpiritTracksWorld(WorldParent):
                 return self.options.randomize_stamps.value in [1, 2, 3]
             bk = self.options.randomize_boss_keys.value if location_name.endswith("Boss Key") else True
             tears = self.options.randomize_tears.value != -1 if location_data.get("conditional", False) == "tears" else True
-            return bk and tears and (location_data["tos_section"] not in self.non_required_sections) or self.options.exclude_sections != "remove"
+            return bk and tears and (location_data["tos_section"] not in self.non_required_sections or self.options.exclude_sections != "remove")
         if "dungeon" in location_data:
             passengers = self.options.randomize_passengers.value if location_name == "Marine Temple Ferrus Force Gem" else True
             stamp = self.options.randomize_stamps.value in [1, 2, 3] if "stamp" in location_data else True

--- a/worlds/tloz_st/archipelago.json
+++ b/worlds/tloz_st/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Spirit Tracks",
-  "world_version": "0.7.2",
+  "world_version": "0.7.3",
   "authors": ["DayKat", "1313e", "Carrotinator", "TriforceDrummer", "Nepecute"],
   "minimum_ap_version": "0.6.0"
 }

--- a/worlds/tloz_st/archipelago.json
+++ b/worlds/tloz_st/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Spirit Tracks",
-  "world_version": "0.7.3",
+  "world_version": "0.7.4",
   "authors": ["DayKat", "1313e", "Carrotinator", "TriforceDrummer", "Nepecute"],
   "minimum_ap_version": "0.6.0"
 }

--- a/worlds/tloz_st/data/Addresses.py
+++ b/worlds/tloz_st/data/Addresses.py
@@ -157,7 +157,7 @@ class STAddr:
     # tos5_boss_door = Address(0x33E182)
     tos5_boss_door = Address(0x33E1Ce)
 
-    mtt_b1_heatoise_trigger = Address(0x389F58, size=4)
+    mtt_b1_heatoise_trigger_pointer = Address(0x1231B4, size=3)
 
     # Object pointer table
     tos_boss_door_pointer = Address(0x265668, size=4)

--- a/worlds/tloz_st/data/Addresses.py
+++ b/worlds/tloz_st/data/Addresses.py
@@ -157,6 +157,8 @@ class STAddr:
     # tos5_boss_door = Address(0x33E182)
     tos5_boss_door = Address(0x33E1Ce)
 
+    mtt_b1_heatoise_trigger = Address(0x389F58, size=4)
+
     # Object pointer table
     tos_boss_door_pointer = Address(0x265668, size=4)
 

--- a/worlds/tloz_st/data/DynamicFlags.py
+++ b/worlds/tloz_st/data/DynamicFlags.py
@@ -475,13 +475,30 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "set_if_true": [(STAddr.adv_flags_31, 0x01)],
         "not_on_entrance": [0x7, 0xB, 0xFB],
     },
-    "Allow Portal sand temple shortcut with item": {  # TODO: Have multiple or states for groups
+    "Allow Portal sand temple shortcut always open from top": {
+        "on_scenes": [0x600],
+        "has_groups": ["Tracks: Sand Realm", "Tracks: Desert Temple Tracks"],
+        "has_slot_data": [("portal_behavior", 1), ("portal_checks", 1)],
+        "set_if_true": [(STAddr.adv_flags_31, 0x01)],
+        "on_entrance": [0xFB],
+        "coords": {"x_max": 80000},
+    },
+    "Allow Portal sand temple shortcut with item": {
         "on_scenes": [0x600],
         "has_groups": ["Tracks: Sand Realm", "Tracks: Desert Temple Tracks"],
         "has_items": [("Portal Unlock: Desert Temple to Sand Realm", 1)],
         "has_slot_data": [("portal_behavior", 2), ("portal_checks", 1)],
         "set_if_true": [(STAddr.adv_flags_31, 0x01)],
         "not_on_entrance": [0x7, 0xB, 0xFB],
+    },
+    "Allow Portal sand temple shortcut with item from top": {
+        "on_scenes": [0x600],
+        "has_groups": ["Tracks: Sand Realm", "Tracks: Desert Temple Tracks"],
+        "has_items": [("Portal Unlock: Desert Temple to Sand Realm", 1)],
+        "has_slot_data": [("portal_behavior", 2), ("portal_checks", 1)],
+        "on_entrance": [0xFB],
+        "set_if_true": [(STAddr.adv_flags_31, 0x01)],
+        "coords": {"x_max": 80000},
     },
     "Close sand portal no item realm tracks": {
         "on_scenes": [0x600],
@@ -494,7 +511,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "on_scenes": [0x600],
         "has_items": [("Portal Unlock: Desert Temple to Sand Realm", 0)],
         "not_has_locations": ["Sand Realm Shoot Temple Portal"],
-        "has_slot_data": [("portal_behavior", 2)],
+        "has_slot_data": [("portal_behavior", 2), ("portal_checks", 1)],
         "unset_if_true": [(STAddr.adv_flags_31, 0x01)],
     },
     "Close sand portal no item temple tracks": {
@@ -508,7 +525,15 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "on_scenes": [0x600],
         "has_slot_data": [("portal_checks", 1)],
         "not_has_locations": ["Sand Realm Shoot Temple Portal"],
-        "on_entrance": [0x7, 0xB, 0xFB],  # will also close if coming from north, but you can reload at sand sanc
+        "on_entrance": [0x7, 0xB],
+        "unset_if_true": [(STAddr.adv_flags_31, 0x01)]
+    },
+    "Close Portal sand temple shortcut right from top": {
+        "on_scenes": [0x600],
+        "has_slot_data": [("portal_checks", 1)],
+        "not_has_locations": ["Sand Realm Shoot Temple Portal"],
+        "on_entrance": [0xFB],
+        "coords": {"x_min": 80000},
         "unset_if_true": [(STAddr.adv_flags_31, 0x01)]
     },
     "Open Portal sand temple shortcut always open": {
@@ -900,11 +925,36 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "reset_flags": ["RESET Remove Forest source", "RESET Remove Snow source",
                         "RESET Remove Ocean source", "RESET Remove Fire source"]
     },
+    "ToS Forest source sections": {
+        "on_scenes": [0x1700],
+        "has_slot_data": [["tos_section_unlocks", 1]],
+        "has_groups": ["Tracks: Forest Source"],
+        "not_has_groups": ["Tracks: Snow Source", "Tracks: Ocean Source", "Tracks: Fire Source"],
+        "set_if_true": [(STAddr.adv_flags_0, 0x10)],
+    },
     "ToS Snow source sections": {
         "on_scenes": [0x1700],
         "has_slot_data": [["tos_section_unlocks", 1]],
         "has_groups": ["Tracks: Snow Source"],
-        "set_if_true": [(STAddr.adv_flags_0, 0x20)],
+        "not_has_groups": ["Tracks: Ocean Source", "Tracks: Fire Source"],
+        "set_if_true": [(STAddr.adv_flags_0, 0x30)],
+        "reset_flags": ["RESET Remove Forest source"]
+    },
+    "ToS Ocean source sections": {
+        "on_scenes": [0x1700],
+        "has_slot_data": [["tos_section_unlocks", 1]],
+        "has_groups": ["Tracks: Ocean Source"],
+        "not_has_groups": ["Tracks: Fire Source"],
+        "set_if_true": [(STAddr.adv_flags_0, 0x70)],
+        "reset_flags": ["RESET Remove Forest source", "RESET Remove Snow source"]
+    },
+    "ToS Fire source sections": {
+        "on_scenes": [0x1700],
+        "has_slot_data": [["tos_section_unlocks", 1]],
+        "has_groups": ["Tracks: Fire Source"],
+        "set_if_true": [(STAddr.adv_flags_0, 0xF0)],
+        "reset_flags": ["RESET Remove Forest source", "RESET Remove Snow source",
+                        "RESET Remove Ocean source"]
     },
     "ToS progressive sections 0": {
         "on_scenes": [0x1700],

--- a/worlds/tloz_st/data/Items.py
+++ b/worlds/tloz_st/data/Items.py
@@ -3,7 +3,6 @@ from .Addresses import STAddr
 from ..Subclasses import STItem
 from typing import Any
 
-
 ITEMS_DATA: dict[str, dict[str, Any]] = {
     #   "No Item": {
     #   'classification': ItemClassification,   # classification category
@@ -24,7 +23,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'progressive': [[STAddr.items_2, 0x02], [STAddr.items_2, 0x04]],
         'item_groups': ["Swords", "Progressive Items", "Equipment"],
 
-        "model": "Sword"
+        "model": "Sword", 
+        "id": 1,
     },
     "Sword": {  # Used when lokomo sword is not progressive, and tied to tears
         'classification': ItemClassification.progression,
@@ -32,7 +32,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         "value": 0x02,
         'item_groups': ["Swords", "Equipment"],
 
-        "model": "Sword"
+        "model": "Sword", 
+        "id": 2,
     },
     "Shield": {
         'classification': ItemClassification.progression_deprioritized,
@@ -40,14 +41,16 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x01,
         'item_groups': ["Equipment"],
 
-        "model": "Shield"
+        "model": "Shield", 
+        "id": 3,
     },
     "Ancient Shield": {
         'classification': ItemClassification.useful,
         'address': STAddr.items_2,
         'value': 0x40,
         'item_groups': ["Equipment"],
-        'model': "Ancient Shield"
+        'model': "Ancient Shield", 
+        "id": 4,
     },
     "Whirlwind": {
         'classification': ItemClassification.progression,
@@ -56,7 +59,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Equipment", "Main Items",
                         "Gust", "Non-Progressive Main Items"],
 
-        "model": "Whirlwind"
+        "model": "Whirlwind", 
+        "id": 5,
     },
     "Bombs (Progressive)": {
         'classification': ItemClassification.progression,
@@ -69,7 +73,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
                         "Bombs"],
 
         "model": "Bomb Bag",
-        "progressive_model": ["Bomb Bag", "Medium Bomb Bag", "Large Bomb Bag"],
+        "progressive_model": ["Bomb Bag", "Medium Bomb Bag", "Large Bomb Bag"], 
+        "id": 6,
     },
     "Bow (Progressive)": {
         'classification': ItemClassification.progression,
@@ -81,7 +86,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
                         "Bow"],
 
         "model": "Bow",
-        "progressive_model": ["Bow", "Medium Quiver", "Large Quiver"],
+        "progressive_model": ["Bow", "Medium Quiver", "Large Quiver"], 
+        "id": 7,
     },
     "Bow of Light": {
         'classification': ItemClassification.progression,
@@ -90,7 +96,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Equipment", "Main Items", "Bows",
                         "Light Arrows", "Light Bow"],
 
-        "model": "Bow of Light"
+        "model": "Bow of Light", 
+        "id": 8,
     },
     "Whip": {
         'classification': ItemClassification.progression,
@@ -98,7 +105,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x04,
         'item_groups': ["Equipment", "Main Items", "Non-Progressive Main Items"],
 
-        "model": "Whip"
+        "model": "Whip", 
+        "id": 9,
     },
     "Boomerang": {
         'classification': ItemClassification.progression,
@@ -106,7 +114,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x02,
         'item_groups': ["Equipment", "Main Items", "Non-Progressive Main Items"],
 
-        "model": "Boomerang"
+        "model": "Boomerang", 
+        "id": 10,
     },
     "Sand Wand": {
         'classification': ItemClassification.progression,
@@ -115,7 +124,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Equipment", "Main Items",
                         "Sand Rod", "Non-Progressive Main Items"],
 
-        "model": "Sand Wand"
+        "model": "Sand Wand", 
+        "id": 11,
     },
     "Spirit Flute": {
         'classification': ItemClassification.progression,
@@ -123,7 +133,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x80,
         'item_groups': ["Equipment",
                         "Spirit Pipes", "Pan Flute", "Flute"],
-        "model": "Spirit Flute"
+        "model": "Spirit Flute", 
+        "id": 12,
     },
 
     # ======= Misc Items==========
@@ -133,7 +144,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         #'address': 0x1BA645,
         #'value': 0x01,
         #'set_bit': [(0x1BA6C8, 1)]
-        "model": "Hero's Clothes"
+        "model": "Hero's Clothes", 
+        "id": 13,
     },
     "Engineer's Clothes": {
         'classification': ItemClassification.filler,
@@ -141,7 +153,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         #'value': 0x01,
         #'set_bit': [(0x1BA6C8, 1)]
         "model": "Engineer's Clothes",
-        "dummy": True
+        "dummy": True, 
+        "id": 14,
     },
     "Compass of Light": {
         'classification': ItemClassification.progression,
@@ -149,25 +162,29 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x40,  # also set adv flag?
         'set_bit': [(STAddr.adv_flags_25, 0x60)],
         'item_groups': ["Rail Items", "Forest Tracks", "Compass"],
-        "model": "Compass of Light",
+        "model": "Compass of Light", 
+        "id": 15,
     },
     "Compass of Light Shard": {
         'classification': ItemClassification.progression,
         "model": "Compass of Light",
         'item_groups': ["Compass", "Compass Shard"],
-        "dummy": True,
+        "dummy": True, 
+        "id": 16,
     },
     "Royal Engineer's Certificate": {
         'classification': ItemClassification,
         'address': STAddr.adv_flags_3,
-        'value': 0x01,
+        'value': 0x01, 
+        "id": 17,
     },
     "Rabbit Net": {
         'classification': ItemClassification.progression,
         'address': STAddr.adv_flags_1a,
         'value': 0x40,
         'item_groups': ["Equipment", "Train Items"],
-        "model": "Rabbit Net"
+        "model": "Rabbit Net", 
+        "id": 18,
     },
     "Stamp Book": {
         'classification': ItemClassification.progression,
@@ -175,11 +192,13 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x02,
         'item_groups': ["Equipment"],
         "model": "Stamp Book",
-        "blocked_scenes": [0x2f0a]
+        "blocked_scenes": [0x2f0a], 
+        "id": 19,
     },
     "Dummy Bow": {
         'classification': ItemClassification.filler,
-        'model': "Bow"
+        'model': "Bow", 
+        "id": 20,
     },
 
     # ======= Songs ==========
@@ -190,7 +209,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x01,
         'item_groups': ["Songs"],
         "model": "SoA",
-        "blocked_scenes": [0x3000]
+        "blocked_scenes": [0x3000], 
+        "id": 21,
     },
     "Song of Healing": {
         'classification': ItemClassification.useful,
@@ -198,7 +218,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x02,
         'item_groups': ["Songs"],
         "model": "SoH",
-        "blocked_scenes": [0x190A, 0x1B0A, 0x1C0A],
+        "blocked_scenes": [0x190A, 0x1B0A, 0x1C0A], 
+        "id": 22,
     },
     "Song of Birds": {
         'classification': ItemClassification.progression,
@@ -206,7 +227,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x04,
         'item_groups': ["Songs"],
         "model": "SoB",
-        "blocked_scenes": [0x2C00]
+        "blocked_scenes": [0x2C00], 
+        "id": 23,
     },
     "Song of Light": {
         'classification': ItemClassification.progression,
@@ -214,7 +236,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x08,
         'item_groups': ["Songs"],
         "model": "SoL",
-        "blocked_scenes": [0x3700]
+        "blocked_scenes": [0x3700], 
+        "id": 24,
     },
     "Song of Discovery": {
         'classification': ItemClassification.progression,
@@ -222,11 +245,11 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x10,
         'item_groups': ["Songs"],
         "model": "SoD",
-        "blocked_scenes": [0x2B00]
+        "blocked_scenes": [0x2B00], 
+        "id": 25,
     },
 
     # ============= Upgrades =============
-
 
     "Heart Container": {
         'classification': ItemClassification.useful,
@@ -236,21 +259,24 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         "tags": ["monotone_incremental"],
         "base_count": 12,
         'item_groups': ["Upgrade Items"],
-        'model': "Heart Container"
+        'model': "Heart Container", 
+        "id": 26,
     },
     "Sword Beam Scroll": {
         'classification': ItemClassification.progression,
         'address': STAddr.items_2,
         'value': 0x0010,
         'item_groups': ["Upgrade Items", "Equipment"],
-        'model': "Green Scroll"
+        'model': "Green Scroll", 
+        "id": 27,
     },
     "Great Spin Scroll": {
         'classification': ItemClassification.useful,
         'address': STAddr.items_2,
         'value': 0x0020,
         'item_groups': ["Upgrade Items", "Equipment"],
-        'model': "Purple Scroll"
+        'model': "Purple Scroll", 
+        "id": 28,
     },
 
     # ============= Train Items =============
@@ -261,51 +287,60 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x80,
         'item_groups': ["Train Items"],
         'model': "Large Bomb Bag",
-        "reload_entrances": [0x2F00]
+        "reload_entrances": [0x2F00], 
+        "id": 29,
     },
     "Portal Unlock: Hyrule Castle to Anouki Village": {
         'classification': ItemClassification.progression,
         # 'address': 0x265744,
         # 'value': 0x08,
         'item_groups': ["Portal Unlocks", "North Forest Portal", "N Forest Portal", "Anouki Portal", "SW Snow Portal"],
-        "reload_entrances": [0x400, 0x500],
+        "reload_entrances": [0x400, 0x500], 
+        "id": 30,
     },
     "Portal Unlock: Trading Post to E Snow Realm": {
         'classification': ItemClassification.progression,
         # 'address': 0x265744,
         # 'value': 0x40,
         'item_groups': ["Portal Unlocks"],
-        "reload_entrances": [0x400, 0x500],
+        "reload_entrances": [0x400, 0x500], 
+        "id": 31,
     },
     "Portal Unlock: Desert Temple to Sand Realm": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
-        "reload_entrances": [0x600],
+        "reload_entrances": [0x600], 
+        "id": 32,
     },
     "Portal Unlock: Sand Valley to Marine Temple": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
-        "reload_entrances": [0x600, 0x700],
+        "reload_entrances": [0x600, 0x700], 
+        "id": 33,
     },
     "Portal Unlock: Forest Cave to Goron Village": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
-        "reload_entrances": [0x400, 0x700],
+        "reload_entrances": [0x400, 0x700], 
+        "id": 34,
     },
     "Portal Unlock: Icy Spring to Mountain Temple": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
-        "reload_entrances": [0x500, 0x700],
+        "reload_entrances": [0x500, 0x700], 
+        "id": 35,
     },
     "Portal Unlock: Mayscore to Ocean Portal Tracks": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
-        "reload_entrances": [0x400, 0x600],
+        "reload_entrances": [0x400, 0x600], 
+        "id": 36,
     },
     "Portal Unlock: Snow Bridge to Island Sanctuary": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
-        "reload_entrances": [0x500, 0x600],
+        "reload_entrances": [0x500, 0x600], 
+        "id": 37,
     },
 
     # ========== Rail Maps ============
@@ -316,44 +351,52 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x80,
         'item_groups': ["Glyphs", "Rail Items", "Forest Tracks", "Major Forest Tracks", "Tracks: Forest Glyph"],
         'model': "Forest Glyph 2",
-        "reload_entrances": [0x2F00],
+        "reload_entrances": [0x2F00], 
+        "id": 38,
     },
     "Snow Glyph": {
         'classification': ItemClassification.progression,
         'address': STAddr.adv_flags_2,
         'value': 0x01,
         'item_groups': ["Glyphs", "Rail Items", "Snow Tracks", "Major Snow Tracks", "Tracks: Snow Glyph"],
-        'model': "Snow Glyph",
+        'model': "Snow Glyph", 
+        "id": 39,
     },
     "Ocean Glyph": {
         'classification': ItemClassification.progression,
         'address': STAddr.adv_flags_2,
         'value': 0x02,
         'item_groups': ["Glyphs", "Rail Items", "Ocean Realm Tracks", "Major Ocean Tracks", "Tracks: Ocean Glyph"],
-        'model': "Ocean Glyph",
+        'model': "Ocean Glyph", 
+        "id": 40,
     },
     "Fire Glyph": {
         'classification': ItemClassification.progression,
         'address': STAddr.adv_flags_2,
         'value': 0x04,
         'item_groups': ["Glyphs", "Rail Items", "Fire Tracks", "Major Fire Tracks", "Tracks: Fire Glyph"],
-        'model': "Fire Glyph",
+        'model': "Fire Glyph", 
+        "id": 41,
     },
-    "Wooded Temple Tracks":{
+    "Wooded Temple Tracks": {
         'classification': ItemClassification.progression,
         'address': STAddr.rail_restorations,
         'value': 0x02,
         'item_groups': ["Restoration Tracks", "Rail Items", "Forest Tracks",
-                        "Forest Restoration", "Forest Realm Restoration", "Major Forest Tracks", "Tracks: Wooded Temple Tracks"],
-        'model': "Forest Glyph 2",
+                        "Forest Restoration", "Forest Realm Restoration", "Major Forest Tracks",
+                        "Tracks: Wooded Temple Tracks"],
+        'model': "Forest Glyph 2", 
+        "id": 42,
     },
     "Blizzard Temple Tracks": {
         'classification': ItemClassification.progression,
         'address': STAddr.rail_restorations,
         'value': 0x04,
         'item_groups': ["Restoration Tracks", "Rail Items", "Snow Tracks",
-                        "Snow Restoration", "Snow Realm Restoration", "Major Snow Tracks", "Tracks: Blizzard Temple Tracks"],
-        'model': "Snow Glyph 2",
+                        "Snow Restoration", "Snow Realm Restoration", "Major Snow Tracks",
+                        "Tracks: Blizzard Temple Tracks"],
+        'model': "Snow Glyph 2", 
+        "id": 43,
     },
     "Marine Temple Tracks": {
         'classification': ItemClassification.progression,
@@ -362,26 +405,31 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Restoration Tracks", "Rail Items", "Ocean Realm Tracks",
                         "Ocean Temple Tracks", "Ocean Restoration", "Ocean Realm Restoration",
                         "Major Ocean Tracks", "Tracks: Marine Temple Tracks"],
-        'model': "Ocean Glyph 3",
+        'model': "Ocean Glyph 3", 
+        "id": 44,
     },
     "Mountain Temple Tracks": {
         'classification': ItemClassification.progression,
         'address': STAddr.rail_restorations,
         'value': 0x10,
         'item_groups': ["Restoration Tracks", "Rail Items", "Fire Tracks", "Major Fire Tracks"
-                        "Fire Temple Tracks", "Fire Restoration", "Fire Realm Restoration", "Mountain Restoration",
+                                                                           "Fire Temple Tracks", "Fire Restoration",
+                        "Fire Realm Restoration", "Mountain Restoration",
                         "Tracks: Mountain Temple Tracks"],
         "set_bits": [(STAddr.adv_flags_1, 0x8)],
-        'model': "Fire Glyph 2",
+        'model': "Fire Glyph 2", 
+        "id": 45,
     },
     "Desert Temple Tracks": {
         'classification': ItemClassification.progression,
         'address': STAddr.rail_restorations,
         'value': 0x20,
         'item_groups': ["Restoration Tracks", "Rail Items", "Desert Tracks", "Major Sand Tracks"
-                        "Desert Restoration", "Sand Temple Tracks", "Sand Restoration", "Sand Realm Restoration",
+                                                                             "Desert Restoration", "Sand Temple Tracks",
+                        "Sand Restoration", "Sand Realm Restoration",
                         "Tracks: Desert Temple Tracks"],
-        'model': "Ocean Glyph 3",
+        'model': "Ocean Glyph 3", 
+        "id": 46,
     },
     # Misc Tracks
     "Snowdrift Station Tracks": {
@@ -391,7 +439,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Rail Items", "Snow Tracks", "Misc Tracks",
                         "Snowdrift Tracks", "Minor Snow Tracks", "Tracks: Snowdrift Station"],
         "model": "Snow Glyph",
-        "vanilla_model": "Force Gem 51"
+        "vanilla_model": "Force Gem 51", 
+        "id": 47,
     },
     "Slippery Station Tracks": {
         'classification': ItemClassification.progression,
@@ -400,7 +449,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Rail Items", "Snow Tracks", "Misc Tracks",
                         "Slippery Tracks", "Minor Snow Tracks", "Tracks: Slippery Station"],
         "model": "Snow Glyph",
-        "vanilla_model": "Force Gem 54"
+        "vanilla_model": "Force Gem 54", 
+        "id": 48,
     },
     "Pirate Hideout Tracks": {
         'classification': ItemClassification.progression,
@@ -409,7 +459,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Rail Items", "Ocean Realm Tracks", "Misc Tracks",
                         "Pirate Tracks", "Minor Ocean Tracks", "Tracks: Pirate Hideout"],
         "model": "Ocean Glyph",
-        "vanilla_model": "Force Gem 18"
+        "vanilla_model": "Force Gem 18", 
+        "id": 49,
     },
     "Lost at Sea Station Tracks": {
         'classification': ItemClassification.progression,
@@ -418,7 +469,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Rail Items", "Ocean Realm Tracks", "Misc Tracks",
                         "LaS Tracks", "Lost at Sea Tracks", "Tracks: Lost at Sea Station"],
         "model": "Ocean Glyph",
-        "vanilla_model": "Force Gem 55"
+        "vanilla_model": "Force Gem 55", 
+        "id": 50,
     },
     "Forest Realm Ocean Shortcut Tracks": {
         'classification': ItemClassification.progression,
@@ -427,15 +479,18 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Rail Items", "Forest Tracks", "Ocean Realm Tracks", "Misc Tracks",
                         "Minor Forest Tracks", "Minor Ocean Tracks", "Tracks: Forest Realm Ocean Shortcut"],
         "model": "Ocean Glyph",
-        "vanilla_model": "Force Gem 42"
+        "vanilla_model": "Force Gem 42", 
+        "id": 51,
     },
     "E Mayscore Bridge Tracks": {
         'classification': ItemClassification.progression,
         'address': STAddr.tracks_0,
         'value': 0x04,
-        'item_groups': ["Rail Items", "Forest Tracks", "Misc Tracks", "Minor Forest Tracks", "Tracks: E Mayscore Bridge"],
+        'item_groups': ["Rail Items", "Forest Tracks", "Misc Tracks", "Minor Forest Tracks",
+                        "Tracks: E Mayscore Bridge"],
         "model": "Forest Glyph",
-        "vanilla_model": "Force Gem 43"
+        "vanilla_model": "Force Gem 43", 
+        "id": 52,
     },
     "Forest Realm SE Portal Tracks": {
         'classification': ItemClassification.progression,
@@ -444,7 +499,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Rail Items", "Forest Tracks", "Misc Tracks", "Minor Forest Tracks",
                         "Tracks: Forest Realm SE Portal"],
         "model": "Forest Glyph",
-        "vanilla_model": "Force Gem 44"
+        "vanilla_model": "Force Gem 44", 
+        "id": 53,
     },
     "W Castle Town Tracks": {
         'classification': ItemClassification.progression,
@@ -452,7 +508,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x20,
         'item_groups': ["Rail Items", "Forest Tracks", "Misc Tracks", "Minor Forest Tracks", "Tracks: W Castle Town"],
         "model": "Forest Glyph",
-        "vanilla_model": "Force Gem 46"
+        "vanilla_model": "Force Gem 46", 
+        "id": 54,
     },
     "W Forest Realm Tracks": {
         'classification': ItemClassification.progression,
@@ -460,15 +517,18 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x40,
         'item_groups': ["Rail Items", "Forest Tracks", "Misc Tracks", "Minor Forest Tracks", "Tracks: W Forest Realm"],
         "model": "Forest Glyph",
-        "vanilla_model": "Force Gem 47"
+        "vanilla_model": "Force Gem 47", 
+        "id": 55,
     },
     "Forest Realm SW Cave Tracks": {
         'classification': ItemClassification.progression,
         'address': STAddr.tracks_0,
         'value': 0x80,
-        'item_groups': ["Rail Items", "Forest Tracks", "Misc Tracks", "Minor Forest Tracks", "Tracks: Forest Realm SW Cave"],
+        'item_groups': ["Rail Items", "Forest Tracks", "Misc Tracks", "Minor Forest Tracks",
+                        "Tracks: Forest Realm SW Cave"],
         "model": "Forest Glyph",
-        "vanilla_model": "Force Gem 48"
+        "vanilla_model": "Force Gem 48", 
+        "id": 56,
     },
     "W Wooded Temple Tracks": {
         'classification': ItemClassification.progression,
@@ -477,7 +537,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Rail Items", "Forest Tracks", "Snow Tracks", "Misc Tracks",
                         "Minor Snow Tracks", "Minor Forest Tracks", "Tracks: W Wooded Temple"],
         "model": "Forest Glyph",
-        "vanilla_model": "Force Gem 49"
+        "vanilla_model": "Force Gem 49", 
+        "id": 57,
     },
     "N Castle Town Tracks": {
         'classification': ItemClassification.progression,
@@ -486,16 +547,18 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Rail Items", "Forest Tracks", "Snow Tracks", "Misc Tracks",
                         "Minor Snow Tracks", "Minor Forest Tracks", "Tracks: N Castle Town"],
         "model": "Forest Glyph",
-        "vanilla_model": "Force Gem 50"
+        "vanilla_model": "Force Gem 50", 
+        "id": 58,
     },
-    "Snow Realm Bridge Tracks": { # has portal to ocean realm
+    "Snow Realm Bridge Tracks": {  # has portal to ocean realm
         'classification': ItemClassification.progression,
         'address': STAddr.tracks_1,
         'value': 0x08,
         'item_groups': ["Rail Items", "Forest Tracks", "Snow Tracks", "Misc Tracks",
                         "Minor Snow Tracks", "Minor Forest Tracks", "Tracks: Snow Realm Bridge"],
         "model": "Snow Glyph",
-        "vanilla_model": "Force Gem 52"
+        "vanilla_model": "Force Gem 52", 
+        "id": 59,
     },
     "N Icy Spring Tracks": {
         'classification': ItemClassification.progression,
@@ -503,21 +566,25 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x10,
         'item_groups': ["Rail Items", "Snow Tracks", "Misc Tracks", "Minor Snow Tracks", "Tracks: N Icy Spring"],
         "model": "Snow Glyph",
-        "vanilla_model": "Force Gem 53"
+        "vanilla_model": "Force Gem 53", 
+        "id": 60,
     },
     "Ocean Portal Tracks": {
         'classification': ItemClassification.progression,
         'address': STAddr.tracks_1,
         'value': 0x80,
-        'item_groups': ["Rail Items", "Ocean Realm Tracks", "Misc Tracks", "Minor Ocean Tracks", "Tracks: Ocean Portal"],
+        'item_groups': ["Rail Items", "Ocean Realm Tracks", "Misc Tracks", "Minor Ocean Tracks",
+                        "Tracks: Ocean Portal"],
         "model": "Ocean Glyph",
-        "vanilla_model": "Force Gem 17"
+        "vanilla_model": "Force Gem 17", 
+        "id": 61,
     },
     "Sand Realm Tracks": {
         'classification': ItemClassification.progression,
         'address': STAddr.tracks_2,
         'value': 0x20,
         'item_groups': ["Rail Items", "Desert Tracks", "Misc Tracks", "Major Sand Tracks", "Tracks: Sand Realm"],
+        "id": 62,
     },
     "Fire Realm Sand Portal Tracks": {
         'classification': ItemClassification.progression,
@@ -527,7 +594,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
                         "Fire to Sand Connection Tracks", "Fire Realm Portal Tracks", "S Fire Realm Portal Tracks",
                         "Minor Fire Tracks", "Minor Sand Tracks", "Tracks: Fire Realm Sand Portal"],
         "model": "Fire Glyph",
-        "vanilla_model": "Force Gem 19"
+        "vanilla_model": "Force Gem 19", 
+        "id": 63,
     },
     "Dark Ore Mine Tracks": {
         'classification': ItemClassification.progression,
@@ -536,7 +604,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Rail Items", "Desert Tracks", "Fire Tracks", "Misc Tracks",
                         "Minor Sand Tracks", "Minor Fire Tracks", "Tracks: Dark Ore Mine"],
         "model": "Fire Glyph",
-        "vanilla_model": "Force Gem 34"
+        "vanilla_model": "Force Gem 34", 
+        "id": 64,
     },
     "Ends of the Earth Tracks": {
         'classification': ItemClassification.progression,
@@ -544,7 +613,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x10,
         'item_groups': ["Rail Items", "Fire Tracks", "Misc Tracks", "Minor Fire Tracks", "Tracks: Ends of the Earth"],
         "model": "Fire Glyph",
-        "vanilla_model": "Force Gem 45"
+        "vanilla_model": "Force Gem 45", 
+        "id": 65,
     },
     "Disorientation Station Tracks": {
         'classification': ItemClassification.progression,
@@ -553,7 +623,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'item_groups': ["Rail Items", "Fire Tracks", "Misc Tracks",
                         "Disorientation Tracks", "Minor Fire Tracks", "Tracks: Disorientation Station"],
         "model": "Fire Glyph",
-        "vanilla_model": "Force Gem 36"
+        "vanilla_model": "Force Gem 36", 
+        "id": 66,
     },
     "Snow Realm Gorge Tracks": {
         'classification': ItemClassification.progression,
@@ -563,46 +634,51 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
                         "E Snow Realm Tracks", "W Fire Realm Tracks",
                         "Minor Snow Tracks", "Minor Fire Tracks", "Tracks: Snow Realm Gorge"],
         "model": "Fire Glyph",
-        "vanilla_model": "Force Gem 35"
+        "vanilla_model": "Force Gem 35", 
+        "id": 67,
     },
 
     # ========= Sources ==============
 
     "Forest Source": {
-      'classification': ItemClassification.progression,
+        'classification': ItemClassification.progression,
         "address": STAddr.adv_flags_0,
         'value': 0x10,
         'set_bit': [[STAddr.source_rails, 2]],
         'item_groups': ["Rail Items", "Sources", "Forest Tracks", "Major Forest Tracks", "Tracks: Forest Source"],
         'model': "Forest Glyph",
-        "reload_entrances": [0x1400, 0x1401, 0x1700],
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 68,
     },
     "Snow Source": {
-      'classification': ItemClassification.progression,
+        'classification': ItemClassification.progression,
         "address": STAddr.adv_flags_0,
         'value': 0x20,
         'set_bit': [[STAddr.source_rails, 4]],
         'item_groups': ["Rail Items", "Sources", "Snow Tracks", "Major Snow Tracks", "Tracks: Snow Source"],
         'model': "Snow Glyph",
-        "reload_entrances": [0x1400, 0x1401, 0x1700]
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 69,
     },
     "Ocean Source": {
-      'classification': ItemClassification.progression,
+        'classification': ItemClassification.progression,
         "address": STAddr.adv_flags_0,
         'value': 0x40,
         'set_bit': [[STAddr.source_rails, 8], (STAddr.adv_flags_9, 0x40)],
         'item_groups': ["Rail Items", "Sources", "Ocean Realm Tracks", "Major Ocean Tracks", "Tracks: Ocean Source"],
         'model': "Ocean Glyph",
-        "reload_entrances": [0x1400, 0x1401, 0x1700]
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 70,
     },
     "Fire Source": {
-      'classification': ItemClassification.progression,
+        'classification': ItemClassification.progression,
         "address": STAddr.adv_flags_0,
         'value': 0x80,
         'set_bit': [[STAddr.source_rails, 0x10]],
         'item_groups': ["Rail Items", "Sources", "Fire Tracks", "Major Fire Tracks", "Tracks: Fire Source"],
         'model': "Fire Glyph",
-        "reload_entrances": [0x1400, 0x1401, 0x1700]
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 71,
     },
     "Sand Source": {  # Only used for TEAO3 unlock?
         'classification': ItemClassification.progression,
@@ -610,7 +686,8 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x1,
         'set_bit': [[STAddr.source_rails, 0x20]],
         'item_groups': ["Sources", "Major Sand Tracks", "Tracks: Sand Source"],
-        'model': "Ocean Glyph",
+        'model': "Ocean Glyph", 
+        "id": 72,
     },
 
     # ========== Rabbits ============
@@ -620,35 +697,40 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         "tags": ["rabbit"],
         'dummy': True,
         "item_groups": ["Grass Rabbits", "Forest Rabbit"],
-        'model': "Rabbit Net",
+        'model': "Rabbit Net", 
+        "id": 73,
     },
     "Snow Rabbit": {
         'classification': ItemClassification.progression_deprioritized,
         "tags": ["rabbit"],
         'dummy': True,
         "item_groups": ["Snow Rabbits"],
-        'model': "Rabbit Net",
+        'model': "Rabbit Net", 
+        "id": 74,
     },
     "Ocean Rabbit": {
         'classification': ItemClassification.progression_deprioritized,
         "tags": ["rabbit"],
         'dummy': True,
         "item_groups": ["Ocean Rabbits"],
-        'model': "Rabbit Net",
+        'model': "Rabbit Net", 
+        "id": 75,
     },
     "Mountain Rabbit": {
         'classification': ItemClassification.progression_deprioritized,
         "tags": ["rabbit"],
         'dummy': True,
         "item_groups": ["Mountain Rabbits", "Fire Rabbit"],
-        'model': "Rabbit Net",
+        'model': "Rabbit Net", 
+        "id": 76,
     },
     "Sand Rabbit": {
         'classification': ItemClassification.progression_deprioritized,
         "tags": ["rabbit"],
         'dummy': True,
         "item_groups": ["Sand Rabbits", "Desert Rabbit"],
-        'model': "Rabbit Net",
+        'model': "Rabbit Net", 
+        "id": 77,
     },
 }
 
@@ -659,11 +741,13 @@ ITEMS_DATA |= {
         'dummy': True,
         'value': n,
         "item_groups": [f"{realm} Rabbits"],
-        'model': "Rabbit Net",
-    } for n in list(range(2, 6)) + [10] for realm in ["Grass", "Snow", "Ocean", "Mountain", "Sand"]
+        'model': "Rabbit Net", 
+        "id": 79,
+    } for i, n in enumerate(list(range(2, 6)) + [10], start=78) for realm in
+    ["Grass", "Snow", "Ocean", "Mountain", "Sand"]
 }
 
-    # ========== Rupees and filler =============
+# ========== Rupees and filler =============
 ITEMS_DATA |= {
     "Green Rupee (1)": {
         'classification': ItemClassification.filler,
@@ -672,7 +756,8 @@ ITEMS_DATA |= {
         "tags": ["incremental"],
         'item_groups': ["Small Rupees"],
 
-        "model": "Green Rupee"
+        "model": "Green Rupee", 
+        "id": 103,
     },
     "Blue Rupee (5)": {
         'classification': ItemClassification.filler,
@@ -681,7 +766,8 @@ ITEMS_DATA |= {
         "tags": ["incremental"],
         'item_groups': ["Small Rupees"],
 
-        "model": "Blue Rupee"
+        "model": "Blue Rupee", 
+        "id": 104,
     },
     "Red Rupee (20)": {
         'classification': ItemClassification.filler,
@@ -690,7 +776,8 @@ ITEMS_DATA |= {
         "tags": ["incremental"],
         'item_groups': ["Small Rupees"],
 
-        "model": "Red Rupee"
+        "model": "Red Rupee", 
+        "id": 105,
     },
     "Big Green Rupee (100)": {
         'classification': ItemClassification.progression_deprioritized,
@@ -699,7 +786,8 @@ ITEMS_DATA |= {
         "tags": ["incremental", 'backup_filler'],
         'item_groups': ["Big Rupees"],
 
-        "model": "Big Green Rupee"
+        "model": "Big Green Rupee", 
+        "id": 106,
     },
     "Big Red Rupee (200)": {
         'classification': ItemClassification.progression_deprioritized,
@@ -708,7 +796,8 @@ ITEMS_DATA |= {
         "tags": ["incremental", 'backup_filler'],
         'item_groups': ["Big Rupees"],
 
-        "model": "Big Red Rupee"
+        "model": "Big Red Rupee", 
+        "id": 107,
     },
     "Gold Rupee (300)": {
         'classification': ItemClassification.progression_deprioritized,
@@ -717,7 +806,8 @@ ITEMS_DATA |= {
         "tags": ["incremental", 'backup_filler'],
         'item_groups': ["Big Rupees"],
 
-        "model": "Gold Rupee"
+        "model": "Gold Rupee", 
+        "id": 108,
     },
     "Pre-Alpha Rupee (5000)": {
         'classification': ItemClassification.progression_deprioritized,
@@ -725,42 +815,48 @@ ITEMS_DATA |= {
         'value': 5000,
         "tags": ["incremental"],
 
-        "model": "Gold Rupee"
+        "model": "Gold Rupee", 
+        "id": 109,
     },
     "Train Part": {
         'classification': ItemClassification.filler,
-        'train_part': True
+        'train_part': True, 
+        "id": 110,
     },
     "Red Potion": {
         'classification': ItemClassification.filler,
-        'address': STAddr.potion_0, #this is potion slot 1
+        'address': STAddr.potion_0,  #this is potion slot 1
         'value': 1,
         'overflow_item': "Big Green Rupee (100)",
         'item_groups': ["Potions"],
         'tags': ["always_process"],
-        "model": "Red Potion"
+        "model": "Red Potion", 
+        "id": 111,
     },
     "Purple Potion": {
         'classification': ItemClassification.filler,
-        'address': STAddr.potion_0, #this is potion slot 1
+        'address': STAddr.potion_0,  #this is potion slot 1
         'value': 2,
         'overflow_item': "Big Green Rupee (100)",
         'item_groups': ["Potions"],
         'tags': ["always_process"],
-        "model": "Purple Potion"
+        "model": "Purple Potion", 
+        "id": 112,
     },
     "Yellow Potion": {
         'classification': ItemClassification.filler,
-        'address': STAddr.potion_0, #this is potion slot 1
+        'address': STAddr.potion_0,  #this is potion slot 1
         'value': 3,
         'overflow_item': "Big Red Rupee (200)",
         'item_groups': ["Potions"],
         'tags': ["always_process"],
-        "model": "Yellow Potion"
+        "model": "Yellow Potion", 
+        "id": 113,
     },
     "Nothing!": {
         'classification': ItemClassification.filler,
-        'dummy': True,
+        'dummy': True, 
+        "id": 114,
     },
     "Refill: Bombs": {
         'classification': ItemClassification.filler,
@@ -769,7 +865,8 @@ ITEMS_DATA |= {
         "refill": "Bombs (Progressive)",
         "tags": ["incremental"],
         'item_groups': ["Refill Items", "Ammo Items"],
-        'model': "Bomb Refill"
+        'model': "Bomb Refill", 
+        "id": 115,
     },
     "Refill: Arrows": {
         'classification': ItemClassification.filler,
@@ -778,146 +875,166 @@ ITEMS_DATA |= {
         "refill": "Bow (Progressive)",
         "tags": ["incremental"],
         'item_groups': ["Refill Items", "Ammo Items"],
-        'model': "Arrow Refill"
+        'model': "Arrow Refill", 
+        "id": 116,
     },
 
     # ========= Treasure =============
 
     "Treasure": {
         'classification': ItemClassification.filler,
-        'dummy': True
+        'dummy': True, 
+        "id": 117,
     },
     "Treasure: Demon Fossil": {
         'classification': ItemClassification.filler,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'address': STAddr.demon_fossil_count,
         'item_groups': ["Common Treasures", "Demon Fossil"],
-        'model': "Demon Fossil"
+        'model': "Demon Fossil", 
+        "id": 118,
     },
     "Treasure: Stalfos Skull": {
         'classification': ItemClassification.filler,
         'address': STAddr.stalfos_skull_count,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'item_groups': ["Common Treasures", "Stalfos Skull"],
-        'model': "Stalfos Skull"
+        'model': "Stalfos Skull", 
+        "id": 119,
     },
     "Treasure: Star Fragment": {
         'classification': ItemClassification.filler,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'address': STAddr.star_fragment_count,
         'item_groups': ["Common Treasures", "Star Fragment"],
-        'model': "Star Fragment"
+        'model': "Star Fragment", 
+        "id": 120,
     },
     "Treasure: Bee Larvae": {
         'classification': ItemClassification.filler,
         'address': STAddr.bee_larvae_count,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'item_groups': ["Common Treasures", "Bee Larvae"],
-        'model': "Bee Larvae"
+        'model': "Bee Larvae", 
+        "id": 121,
     },
     "Treasure: Wood Heart": {
         'classification': ItemClassification.filler,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'address': STAddr.wood_heart_count,
         'item_groups': ["Common Treasures", "Wood Heart"],
-        'model': "Wood Heart"
+        'model': "Wood Heart", 
+        "id": 122,
     },
     "Treasure: Dark Pearl Loop": {
         'classification': ItemClassification.progression_deprioritized,
         'address': STAddr.dark_pearl_loop_count,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'item_groups': ["Uncommon Treasures", "Dark Pearl Loop"],
-        'model': "Dark Pearl Loop"
+        'model': "Dark Pearl Loop", 
+        "id": 123,
     },
     "Treasure: White Pearl Loop": {
         'classification': ItemClassification.progression_deprioritized,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'address': STAddr.white_pearl_loop_count,
         'item_groups': ["Uncommon Treasures", "White Pearl Loop", "Pearl Loop"],
-        'model': "White Pearl Loop"
+        'model': "White Pearl Loop", 
+        "id": 124,
     },
     "Treasure: Ruto Crown": {
         'classification': ItemClassification.progression_deprioritized,
         'address': STAddr.ruto_crown_count,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'item_groups': ["Uncommon Treasures", "Ruto Crown"],
-        'model': "Ruto Crown"
+        'model': "Ruto Crown", 
+        "id": 125,
     },
     "Treasure: Dragon Scale": {
         'classification': ItemClassification.progression_deprioritized,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'address': STAddr.dragon_scale_count,
         'item_groups': ["Uncommon Treasures", "Dragon Scale"],
-        'model': "Dragon Scale"
+        'model': "Dragon Scale", 
+        "id": 126,
     },
     "Treasure: Pirate's Necklace": {
         'classification': ItemClassification.progression_deprioritized,
         'address': STAddr.pirates_necklace_count,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'item_groups': ["Uncommon Treasures", "Pirate Necklace"],
-        'model': "Pirate Necklace"
+        'model': "Pirate Necklace", 
+        "id": 127,
     },
     "Treasure: Palace Dish": {
         'classification': ItemClassification.progression_deprioritized,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'address': STAddr.palace_dish_count,
         'item_groups': ["Rare Treasures", "Palace Dish"],
-        'model': "Palace Dish"
+        'model': "Palace Dish", 
+        "id": 128,
     },
     "Treasure: Goron Amber": {
         'classification': ItemClassification.progression_deprioritized,
         'address': STAddr.goron_amber_count,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'item_groups': ["Rare Treasures", "Goron Amber"],
-        'model': "Goron Amber"
+        'model': "Goron Amber", 
+        "id": 129,
     },
     "Treasure: Mystic Jade": {
         'classification': ItemClassification.progression_deprioritized,
         'address': STAddr.mystic_jade_count,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'item_groups': ["Rare Treasures", "Mystic Jade"],
-        'model': "Mystic Jade"
+        'model': "Mystic Jade", 
+        "id": 130,
     },
     "Treasure: Ancient Coin": {
         'classification': ItemClassification.progression_deprioritized,
         'address': STAddr.ancient_coin_count,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'item_groups': ["Rare Treasures", "Ancient Coin"],
-        'model': "Ancient Coin"
+        'model': "Ancient Coin", 
+        "id": 131,
     },
     "Treasure: Priceless Stone": {
         'classification': ItemClassification.progression,
         'address': STAddr.priceless_stone_count,
         "tags": ['treasure', 'backup_filler', 'incremental'],
         'item_groups': ["Super Rare Treasures", "Priceless Stone", "Alchemy Stone"],
-        'model': "Alchemy Stone"
+        'model': "Alchemy Stone", 
+        "id": 132,
     },
     "Treasure: Regal Ring": {
         'classification': ItemClassification.progression,
         'address': STAddr.regal_ring_count,
         "tags": ['treasure', 'incremental'],
         'item_groups': ["Super Rare Treasures", "Regal Ring"],
-        'model': "Regal Ring"
+        'model': "Regal Ring", 
+        "id": 133,
     },
 
     # =========== Keys ============
 
-     "Small Key (Tunnel to ToS)": {
+    "Small Key (Tunnel to ToS)": {
         'classification': ItemClassification.progression,
         'address': STAddr.small_keys,
         'dungeon': 0x18,
         "tags": ["incremental"],
         'item_groups': ["Small Keys"],
-        "model": "Key"
-     },
+        "model": "Key", 
+        "id": 134,
+    },
     "Small Key (Wooded Temple)": {
         'classification': ItemClassification.progression,
         'address': STAddr.small_keys,
         'dungeon': 0x19,
         "tags": ["incremental"],
         'item_groups': ["Small Keys"],
-         "model": "Key"
-     },
+        "model": "Key", 
+        "id": 135,
+    },
     "Keyring (Wooded Temple)": {
         'classification': ItemClassification.progression,
         'address': STAddr.small_keys,
@@ -925,15 +1042,17 @@ ITEMS_DATA |= {
         'value': 2,
         "tags": ["incremental"],
         'item_groups': ["Keyrings"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 136,
     },
     "Small Key (ToS)": {
         'classification': ItemClassification.progression,
         'address': STAddr.small_keys,
         'dungeon': 0x13,
-         "tags": ["incremental"],
+        "tags": ["incremental"],
         'item_groups': ["Small Keys", "Small Key ToS"],
-         "model": "Key"
+        "model": "Key", 
+        "id": 137,
     },
     "Small Key (ToS 2)": {
         'classification': ItemClassification.progression,
@@ -943,7 +1062,8 @@ ITEMS_DATA |= {
         "rooms": [3, 4, 5, 6, 0x29],
         "section": 2,
         'item_groups': ["Small Keys", "Small Key ToS"],
-         "model": "Key"
+        "model": "Key", 
+        "id": 138,
     },
     "Keyring (ToS 2)": {
         'classification': ItemClassification.progression,
@@ -954,7 +1074,8 @@ ITEMS_DATA |= {
         "section": 2,
         'value': 2,
         'item_groups': ["Keyrings"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 139,
     },
     "Small Key (ToS 4)": {
         'classification': ItemClassification.progression,
@@ -964,7 +1085,8 @@ ITEMS_DATA |= {
         "rooms": [0xc, 0xd, 0xe, 0xf, 0x10],
         "section": 4,
         'item_groups': ["Small Keys", "Small Key ToS"],
-         "model": "Key"
+        "model": "Key", 
+        "id": 140,
     },
     "Keyring (ToS 4)": {
         'classification': ItemClassification.progression,
@@ -975,7 +1097,8 @@ ITEMS_DATA |= {
         "section": 4,
         'value': 3,
         'item_groups': ["Keyrings"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 141,
     },
     "Small Key (ToS 5)": {
         'classification': ItemClassification.progression,
@@ -985,7 +1108,8 @@ ITEMS_DATA |= {
         "rooms": [0x11, 0x12, 0x13, 0x14, 0x17, 0x18],
         "section": 5,
         'item_groups': ["Small Keys", "Small Key ToS"],
-         "model": "Key"
+        "model": "Key", 
+        "id": 142,
     },
     "Keyring (ToS 5)": {
         'classification': ItemClassification.progression,
@@ -996,7 +1120,8 @@ ITEMS_DATA |= {
         "section": 5,
         'value': 2,
         'item_groups': ["Keyrings"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 143,
     },
     "Small Key (ToS 6)": {
         'classification': ItemClassification.progression,
@@ -1006,7 +1131,8 @@ ITEMS_DATA |= {
         "rooms": [0x1d, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x2c, 0x2d],
         "section": 6,
         'item_groups': ["Small Keys", "Small Key ToS"],
-         "model": "Key"
+        "model": "Key", 
+        "id": 144,
     },
     "Keyring (ToS 6)": {
         'classification': ItemClassification.progression,
@@ -1017,15 +1143,17 @@ ITEMS_DATA |= {
         "rooms": [0x1d, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x2c, 0x2d],
         "section": 6,
         'item_groups': ["Keyrings"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 145,
     },
     "Small Key (Blizzard Temple)": {
         'classification': ItemClassification.progression,
         'address': STAddr.small_keys,
         'dungeon': 0x1A,
-         "tags": ["incremental"],
+        "tags": ["incremental"],
         'item_groups': ["Small Keys"],
-         "model": "Key"
+        "model": "Key", 
+        "id": 146,
     },
     "Keyring (Blizzard Temple)": {
         'classification': ItemClassification.progression,
@@ -1034,7 +1162,8 @@ ITEMS_DATA |= {
         'value': 1,
         "tags": ["incremental"],
         'item_groups': ["Keyrings"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 147,
     },
     "Small Key (Marine Temple)": {
         'classification': ItemClassification.progression,
@@ -1042,7 +1171,8 @@ ITEMS_DATA |= {
         'dungeon': 0x1B,
         "tags": ["incremental"],
         'item_groups': ["Small Keys"],
-         "model": "Key"
+        "model": "Key", 
+        "id": 148,
     },
     "Keyring (Marine Temple)": {
         'classification': ItemClassification.progression,
@@ -1051,7 +1181,8 @@ ITEMS_DATA |= {
         'value': 2,
         "tags": ["incremental"],
         'item_groups': ["Keyrings"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 149,
     },
     "Small Key (Mountain Temple)": {
         'classification': ItemClassification.progression,
@@ -1059,7 +1190,8 @@ ITEMS_DATA |= {
         'dungeon': 0x1C,
         "tags": ["incremental"],
         'item_groups': ["Small Keys"],
-         "model": "Key"
+        "model": "Key", 
+        "id": 150,
     },
     "Keyring (Mountain Temple)": {
         'classification': ItemClassification.progression,
@@ -1068,7 +1200,8 @@ ITEMS_DATA |= {
         'value': 3,
         "tags": ["incremental"],
         'item_groups': ["Keyrings"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 151,
     },
     "Small Key (Desert Temple)": {
         'classification': ItemClassification.progression,
@@ -1076,7 +1209,8 @@ ITEMS_DATA |= {
         'dungeon': 0x1D,
         "tags": ["incremental"],
         'item_groups': ["Small Keys"],
-         "model": "Key"
+        "model": "Key", 
+        "id": 152,
     },
     "Keyring (Desert Temple)": {
         'classification': ItemClassification.progression,
@@ -1085,84 +1219,97 @@ ITEMS_DATA |= {
         'value': 2,
         "tags": ["incremental"],
         'item_groups': ["Keyrings"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 153,
     },
     "Boss Key (Blizzard Temple)": {
         'classification': ItemClassification.progression,
         'item_groups': ["Boss Keys", "Blizzard Temple Boss Key"],
         "dummy": True,
-        "model": "Boss Key"
+        "model": "Boss Key", 
+        "id": 154,
     },
     "Boss Key (Wooded Temple)": {
         'classification': ItemClassification.progression,
         'dungeon': 0x19,
         'item_groups': ["Boss Keys", "Wooded Temple Boss Key", "Forest Temple Boss Key", "Boss Key Forest Temple"],
         "dummy": True,
-        "model": "Boss Key"
+        "model": "Boss Key", 
+        "id": 155,
     },
     "Boss Key (Marine Temple)": {
         'classification': ItemClassification.progression,
         'item_groups': ["Boss Keys", "Ocean Temple Boss Key", "Marine Temple Boss Key", "Boss Key Ocean Temple"],
         "dummy": True,
-        "model": "Boss Key"
+        "model": "Boss Key", 
+        "id": 156,
     },
     "Boss Key (Mountain Temple)": {
         'classification': ItemClassification.progression,
         'item_groups': ["Boss Keys", "Mountain Temple Boss Key", "Boss Key Fire Temple", "Fire Temple Boss Key"],
         "dummy": True,
-        "model": "Boss Key"
+        "model": "Boss Key", 
+        "id": 157,
     },
     "Boss Key (Desert Temple)": {
         'classification': ItemClassification.progression,
         'item_groups': ["Boss Keys", "Desert Temple Boss Key", "Boss Key Sand Temple", "Sand Temple Boss Key"],
         "dummy": True,
-        "model": "Boss Key"
+        "model": "Boss Key", 
+        "id": 158,
     },
     "Boss Key (ToS 3)": {
         'classification': ItemClassification.progression,
         'item_groups': ["Boss Keys", "Boss Key (ToS)"],
         "dummy": True,
-        "model": "Boss Key"
+        "model": "Boss Key", 
+        "id": 159,
     },
     "Boss Key (ToS 5)": {
         'classification': ItemClassification.progression,
         'item_groups': ["Boss Keys", "Boss Key (ToS)"],
         "dummy": True,
-        "model": "Boss Key"
+        "model": "Boss Key", 
+        "id": 160,
     },
     "Mountain Temple Snurglar Key": {
         'classification': ItemClassification.progression,
         'dummy': True,
         'item_groups': ["Misc Keys", "Snurglar Key"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 161,
     },
     "Orange Snurglar Key": {
         'classification': ItemClassification.progression,
         "address": STAddr.snurglin_keys,
         "value": 0x02,
         'item_groups': ["Misc Keys", "Snurglar Key"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 162,
     },
     "Purple Snurglar Key": {
         'classification': ItemClassification.progression,
         "address": STAddr.snurglin_keys,
         "value": 0x04,
         'item_groups': ["Misc Keys", "Snurglar Key"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 163,
     },
     "Gold Snurglar Key": {
         'classification': ItemClassification.progression,
         "address": STAddr.snurglin_keys,
         "value": 0x08,
         'item_groups': ["Misc Keys", "Snurglar Key"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 164,
     },
     "Snurglar Keyring": {
         'classification': ItemClassification.progression,
         "address": STAddr.snurglin_keys,
         "value": 0x08,
         'item_groups': ["Keyrings", "Snurglar Key"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 165,
     },
 
     # Tears
@@ -1172,7 +1319,8 @@ ITEMS_DATA |= {
         'value': 1,
         "tags": ["always_process"],
         'item_groups': ["Tears of Light", "Small Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 166,
     },
     "Tear of Light (ToS 1)": {
         'classification': ItemClassification.progression,
@@ -1180,7 +1328,8 @@ ITEMS_DATA |= {
         "rooms": [0, 1, 0x28],
         "tags": ["always_process"],
         'item_groups': ["Unique Tears of Light", "Small Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 167,
     },
     "Tear of Light (ToS 2)": {
         'classification': ItemClassification.progression,
@@ -1188,7 +1337,8 @@ ITEMS_DATA |= {
         "rooms": [3, 4, 5, 0x29],
         "tags": ["always_process"],
         'item_groups': ["Unique Tears of Light", "Small Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 168,
     },
     "Tear of Light (ToS 3)": {
         'classification': ItemClassification.progression,
@@ -1196,7 +1346,8 @@ ITEMS_DATA |= {
         "rooms": [7, 8, 9, 0xa, 0x15, 0x16, 0x2A],
         "tags": ["always_process"],
         'item_groups': ["Unique Tears of Light", "Small Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 169,
     },
     "Tear of Light (ToS 4)": {
         'classification': ItemClassification.progression,
@@ -1204,7 +1355,8 @@ ITEMS_DATA |= {
         "rooms": [0xc, 0xd, 0xe, 0xf, 0x10],
         "tags": ["always_process"],
         'item_groups': ["Unique Tears of Light", "Small Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 170,
     },
     "Tear of Light (ToS 5)": {
         'classification': ItemClassification.progression,
@@ -1212,7 +1364,8 @@ ITEMS_DATA |= {
         "rooms": [0x11, 0x12, 0x13, 0x14, 0x17, 0x18],
         "tags": ["always_process"],
         'item_groups': ["Unique Tears of Light", "Small Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 171,
     },
     "Tear of Light (ToS 6)": {
         'classification': ItemClassification.progression,
@@ -1220,7 +1373,8 @@ ITEMS_DATA |= {
         "tags": ["always_process"],
         "rooms": [0x1d, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x2c, 0x2d],
         'item_groups': ["Unique Tears of Light", "Small Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 172,
     },
     "Tear of Light (All Sections)": {
         'classification': ItemClassification.progression,
@@ -1228,13 +1382,15 @@ ITEMS_DATA |= {
         "rooms": range(0x30),
         'item_groups': ["Universal Tears of Light", "Small Tears of Light",
                         "Tear of Light (Global)"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 173,
     },
     "Tear of Light (Progressive)": {
         'classification': ItemClassification.progression,
         "address": STAddr.tears_of_light,
         'item_groups': ["Progressive Tears of Light", "Small Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 174,
     },
     "Big Tear of Light (ToS 1)": {
         'classification': ItemClassification.progression,
@@ -1242,7 +1398,8 @@ ITEMS_DATA |= {
         'value': 3,
         "rooms": [0, 1, 0x28],
         'item_groups': ["Unique Tears of Light", "Big Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 175,
     },
     "Big Tear of Light (ToS 2)": {
         'classification': ItemClassification.progression,
@@ -1250,7 +1407,8 @@ ITEMS_DATA |= {
         'value': 3,
         "rooms": [3, 4, 5, 0x29],
         'item_groups': ["Unique Tears of Light", "Big Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 176,
     },
     "Big Tear of Light (ToS 3)": {
         'classification': ItemClassification.progression,
@@ -1258,7 +1416,8 @@ ITEMS_DATA |= {
         'value': 3,
         "rooms": [7, 8, 9, 0xa, 0x15, 0x16, 0x2A],
         'item_groups': ["Unique Tears of Light", "Big Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 177,
     },
     "Big Tear of Light (ToS 4)": {
         'classification': ItemClassification.progression,
@@ -1266,7 +1425,8 @@ ITEMS_DATA |= {
         'value': 3,
         "rooms": [0xc, 0xd, 0xe, 0xf, 0x10],
         'item_groups': ["Unique Tears of Light", "Big Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 178,
     },
     "Big Tear of Light (ToS 5)": {
         'classification': ItemClassification.progression,
@@ -1274,7 +1434,8 @@ ITEMS_DATA |= {
         'value': 3,
         "rooms": [0x11, 0x12, 0x13, 0x14, 0x17, 0x18],
         'item_groups': ["Unique Tears of Light", "Big Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 179,
     },
     "Big Tear of Light (ToS 6)": {
         'classification': ItemClassification.progression,
@@ -1282,14 +1443,16 @@ ITEMS_DATA |= {
         'value': 3,
         "rooms": [0x1d, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x2c, 0x2d],
         'item_groups': ["Unique Tears of Light", "Big Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 180,
     },
     "Big Tear of Light (Progressive)": {
         'classification': ItemClassification.progression,
         "address": STAddr.tears_of_light,
         'value': 3,
         'item_groups': ["Progressive Tears of Light", "Big Tears of Light"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 181,
     },
     "Big Tear of Light (All Sections)": {
         'classification': ItemClassification.progression,
@@ -1298,7 +1461,8 @@ ITEMS_DATA |= {
         "value": 3,
         'item_groups': ["Universal Tears of Light", "Big Tears of Light",
                         "Big Tear of Light (Global)"],
-        'model': "Tear of Light"
+        'model': "Tear of Light", 
+        "id": 182,
     },
 
     # Trade Quest and misc
@@ -1308,50 +1472,58 @@ ITEMS_DATA |= {
     # Trains
     "Train: Bright Train": {
         'classification': ItemClassification.useful,
-         "tags": ["backup_filler"],
-        'train': 1
+        "tags": ["backup_filler"],
+        'train': 1, 
+        "id": 183,
     },
     "Train: Iron Train": {
         'classification': ItemClassification.useful,
-         "tags": ["backup_filler"],
-        'train': 2
+        "tags": ["backup_filler"],
+        'train': 2, 
+        "id": 184,
     },
     "Train: Stone Train": {
         'classification': ItemClassification.useful,
-         "tags": ["backup_filler"],
-        'train': 3
+        "tags": ["backup_filler"],
+        'train': 3, 
+        "id": 185,
     },
     "Train: Vintage Train": {
         'classification': ItemClassification.useful,
-         "tags": ["backup_filler"],
-        'train': 4
+        "tags": ["backup_filler"],
+        'train': 4, 
+        "id": 186,
     },
     "Train: Demon Train": {
         'classification': ItemClassification.useful,
-         "tags": ["backup_filler"],
-        'train': 5
+        "tags": ["backup_filler"],
+        'train': 5, 
+        "id": 187,
     },
     "Train: Tropical Train": {
         'classification': ItemClassification.useful,
-         "tags": ["backup_filler"],
-        'train': 6
+        "tags": ["backup_filler"],
+        'train': 6, 
+        "id": 188,
     },
     "Train: Dignified Train": {
         'classification': ItemClassification.useful,
-         "tags": ["backup_filler"],
-        'train': 7
+        "tags": ["backup_filler"],
+        'train': 7, 
+        "id": 189,
     },
     "Train: Golden Train": {
         'classification': ItemClassification.useful,
-         "tags": ["backup_filler"],
-        'train': 8
+        "tags": ["backup_filler"],
+        'train': 8, 
+        "id": 190,
     },
 
     "_UT_Glitched_Logic": {  # Shows yellow logic in UT
         "classification": ItemClassification.progression,
-        "dummy": True,
+        "dummy": True, 
+        "id": 191,
     },
-
 
     # IDs are not fixed yet, but determined by order. Put new items here until an update that breaks compatibility, and move them then.
     "Tower of Spirits Base": {
@@ -1359,42 +1531,48 @@ ITEMS_DATA |= {
         "dummy": True,
         'item_groups': ["Tower of Spirit Unlocks"],
         "model": "Forest Glyph",
-        "reload_entrances": [0x400, 0x500, 0x600, 0x700],
+        "reload_entrances": [0x400, 0x500, 0x600, 0x700], 
+        "id": 192,
     },
     "Progressive ToS Section": {
         "classification": ItemClassification.progression,
         "dummy": True,
         'item_groups': ["Tower of Spirit Unlocks"],
         "model": "Forest Glyph",
-        "reload_entrances": [0x400, 0x500, 0x600, 0x700],
+        "reload_entrances": [0x400, 0x500, 0x600, 0x700], 
+        "id": 193,
     },
     # Overworld eventy things
     "Repair Trading Post Bridge": {
         "classification": ItemClassification.progression,
         "address": STAddr.adv_flags_17,
         "value": 0x10,
-        "model": "Forest Glyph"
+        "model": "Forest Glyph", 
+        "id": 194,
     },
     "Snowfall Sanctuary Cave Key": {
         "classification": ItemClassification.progression,
         "address": STAddr.adv_flags_b,
         "value": 0x10,
         "item_groups": ["Misc Keys"],
-        "model": "Key"
+        "model": "Key", 
+        "id": 195,
     },
     "Prize Postcards (10)": {
         "classification": ItemClassification.filler,
         "address": STAddr.postcard_count,
         "value": 10,
         "tags": ["incremental"],
-        "model": "Prize Postcards"
+        "model": "Prize Postcards", 
+        "id": 196,
     },
     "Wagon": {  # US Freight Car, Neutral Something else?
         "classification": ItemClassification.progression,
         "address": STAddr.adv_flags_4,
         "value": 0x2,
         'item_groups': ["Train Items"],
-        'model': "Engineer's Clothes",
+        'model': "Engineer's Clothes", 
+        "id": 197,
     },
     # Passengers
     "Passenger: Kenzo": {
@@ -1403,7 +1581,8 @@ ITEMS_DATA |= {
         "item_groups": ["Passengers", "Kenzo"],
         "address": STAddr.adv_flags_18,
         "value": 0x20,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 198,
     },
     "Passenger: Kenzo 2": {
         "classification": ItemClassification.progression,
@@ -1411,7 +1590,8 @@ ITEMS_DATA |= {
         "item_groups": ["Passengers", "Kenzo"],
         "address": STAddr.adv_flags_3c,
         "value": 0x10,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 199,
     },
     "Passenger: Joe": {
         "classification": ItemClassification.progression,
@@ -1419,7 +1599,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_3c,
         "value": 0x2,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 200,
     },
     "Passenger: Noko": {
         "classification": ItemClassification.progression,
@@ -1427,7 +1608,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_3a,
         "value": 0x10,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 201,
     },
     "Passenger: Mona": {
         "classification": ItemClassification.progression,
@@ -1435,7 +1617,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_3b,
         "value": 0x20,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 202,
     },
     "Passenger: Ferrus": {
         "classification": ItemClassification.progression,
@@ -1443,7 +1626,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_3a,
         "value": 0x80,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 203,
     },
     "Passenger: Alfonzo": {
         "classification": ItemClassification.progression,
@@ -1451,7 +1635,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_11,
         "value": 0x40,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 204,
     },
     "Passenger: Dovok": {
         "classification": ItemClassification.progression,
@@ -1459,7 +1644,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_36,
         "value": 0x4,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 205,
     },
     "Passenger: Snow Goron": {
         "classification": ItemClassification.progression,
@@ -1467,7 +1653,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_38,
         "value": 0x2,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 206,
     },
     "Passenger: City Goron": {
         "classification": ItemClassification.progression,
@@ -1475,7 +1662,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_3a,
         "value": 0x1,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 207,
     },
     "Passenger: Teacher": {
         "classification": ItemClassification.filler,
@@ -1483,7 +1671,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_42,
         "value": 0x10,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 208,
     },
     "Passenger: Kofu": {
         "classification": ItemClassification.progression,
@@ -1491,7 +1680,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_37,
         "value": 0x20,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 209,
     },
     "Passenger: Carben": {
         "classification": ItemClassification.progression,
@@ -1499,7 +1689,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_9,
         "value": 0x10,
-        "model": "Letter",
+        "model": "Letter", 
+        "id": 210,
     },
     "Passenger: Wadatsumi": {
         "classification": ItemClassification.progression,
@@ -1507,7 +1698,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_34,
         "value": 0x40,
-        "model": "Letter",
+        "model": "Letter", 
+        "id": 211,
     },
     "Passenger: Wood": {
         "classification": ItemClassification.filler,
@@ -1515,7 +1707,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_36,
         "value": 0x2,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 212,
     },
     "Passenger: Morris": {
         "classification": ItemClassification.filler,
@@ -1523,7 +1716,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_35,
         "value": 0x80,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 213,
     },
     "Passenger: Yamahiko": {
         "classification": ItemClassification.filler,
@@ -1531,7 +1725,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_35,
         "value": 0x40,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 214,
     },
     "Passenger: Mash": {
         "classification": ItemClassification.filler,
@@ -1539,7 +1734,8 @@ ITEMS_DATA |= {
         'tags': ["always_process"],
         "address": STAddr.adv_flags_36,
         "value": 0x1,
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 215,
     },
 
     # Cargo
@@ -1547,48 +1743,56 @@ ITEMS_DATA |= {
         "classification": ItemClassification.progression,
         "item_groups": ["Cargo", "Lumber", "Wood", "Logs", "Timber"],
         'tags': ["always_process"],
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 216,
     },
     "Cargo: Mega Ice": {
         "classification": ItemClassification.progression,
         "item_groups": ["Cargo", "Mega Ice", "Ice"],
         'tags': ["always_process"],
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 217,
     },
     "Cargo: Goron Steel": {
         "classification": ItemClassification.progression,
         "item_groups": ["Cargo", "Goron Steel", "Steel", "Goron Iron", "Iron"],
         'tags': ["always_process"],
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 218,
     },
     "Cargo: Fish": {
         "classification": ItemClassification.progression,
         "item_groups": ["Cargo", "Fish"],
         'tags': ["always_process"],
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 219,
     },
     "Cargo: Vessel": {
         "classification": ItemClassification.progression,
         "item_groups": ["Cargo", "Vessel", "Pot", "Vase"],
         'tags': ["always_process"],
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 220,
     },
     "Cargo: Cuccos": {
         "classification": ItemClassification.progression,
         "item_groups": ["Cargo", "Cuccos"],
         'tags': ["always_process"],
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 221,
     },
     "Cargo: Cuccos (5)": {
         "classification": ItemClassification.progression,
         "item_groups": ["Cargo", "Cuccos", "Cuccos (5)"],
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 222,
     },
     "Cargo: Dark Ore": {
         "classification": ItemClassification.progression,
         "item_groups": ["Cargo", "Dark Ore", "Ore"],
         'tags': ["always_process"],
-        "model": "Letter"
+        "model": "Letter", 
+        "id": 223,
     },
 
     # Stamps
@@ -1596,145 +1800,169 @@ ITEMS_DATA |= {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 1,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 224,
     },
     "Stamp: Outset Village": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 2,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 225,
     },
     "Stamp: Mayscore": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 3,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 226,
     },
     "Stamp: Woodland Sanctuary": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 4,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 227,
     },
     "Stamp: Anouki Village": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 5,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 228,
     },
     "Stamp: Snowfall Sanctuary": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 6,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 229,
     },
     "Stamp: Papuzia Village": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 7,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 230,
     },
     "Stamp: Island Sanctuary": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 8,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 231,
     },
     "Stamp: Goron Village": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 9,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 232,
     },
     "Stamp: Valley Sanctuary": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xA,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 233,
     },
     "Stamp: Dune Sanctuary": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xB,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 234,
     },
     "Stamp: Wooded Temple": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xC,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 235,
     },
     "Stamp: Blizzard Temple": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xD,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 236,
     },
     "Stamp: Marine Temple": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xE,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 237,
     },
     "Stamp: Mountain Temple": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xF,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 238,
     },
     "Stamp: Desert Temple": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0x10,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 239,
     },
     "Stamp: Pirate Hideout": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0x11,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 240,
     },
     "Stamp: Trading Post": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0x12,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 241,
     },
     "Stamp: Icy Spring": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0x13,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 242,
     },
     "Stamp: Tower of Spirits": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 243,
     },
     "Stamp Pack (2)": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamp Packs"],
         "value": 2,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 244,
     },
     "Stamp Pack (3)": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamp Packs"],
         "value": 3,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 245,
     },
     "Stamp Pack (4)": {
         "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamp Packs"],
         "value": 4,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 246,
     },
     "Stamp Pack (5)": {
         "classification": ItemClassification.progression,
         "item_groups": ["Stamp Packs"],
         "value": 5,
-        "model": "Stamp Book"
+        "model": "Stamp Book", 
+        "id": 247,
     },
     # Custom Track Combinations
     "Western Forest Tracks": {
@@ -1744,7 +1972,8 @@ ITEMS_DATA |= {
         "set_bit": [(STAddr.tracks_1, 0x1)],
         'model': "Forest Glyph",
         "item_groups": ["Tracks: W Wooded Temple", "Tracks: W Forest Realm", "Tracks: Forest Realm SW Cave",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"], 
+        "id": 248,
     },
     "Anouki Village Tracks": {
         'classification': ItemClassification.progression,
@@ -1753,7 +1982,8 @@ ITEMS_DATA |= {
         "set_bit": [(STAddr.tracks_1, 0x9)],
         'model': "Snow Glyph",
         "item_groups": ["Tracks: Snow Glyph", "Tracks: Snow Realm Bridge", "Tracks: W Wooded Temple",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"], 
+        "id": 249,
     },
     "Thawland Tracks": {
         'classification': ItemClassification.progression,
@@ -1765,7 +1995,8 @@ ITEMS_DATA |= {
         "item_groups": ["Tracks: Snow Source", "Tracks: N Castle Town", "Tracks: Blizzard Temple Tracks",
                         "Tracks: Snow Realm Gorge", "Tracks: N Icy Spring",
                         "Thematic Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700]
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 250,
     },
     "Blizzard Tracks": {
         'classification': ItemClassification.progression,
@@ -1776,18 +2007,21 @@ ITEMS_DATA |= {
         "item_groups": ["Tracks: Blizzard Temple Tracks", "Tracks: Snowdrift Station",
                         "Tracks: Slippery Station", "Tracks: Snow Source",
                         "Thematic Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700]
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 251,
     },
     "Castle Tracks": {
         'classification': ItemClassification.progression,
         "address": STAddr.restorations,
         "value": 0x80,
-        "set_bit": [(STAddr.tracks_1, 0x2), (STAddr.tracks_0, 0x20), (STAddr.source_rails, 0x2), (STAddr.sources, 0x10),],
+        "set_bit": [(STAddr.tracks_1, 0x2), (STAddr.tracks_0, 0x20), (STAddr.source_rails, 0x2),
+                    (STAddr.sources, 0x10), ],
         'model': "Forest Glyph",
         "item_groups": ["Tracks: N Castle Town", "Tracks: Forest Glyph", "Tracks: W Castle Town Tracks",
                         "Tracks: Forest Source",
                         "Thematic Track Groupings"],
-        "reload_entrances": [0x2f00, 0x1400, 0x1401, 0x1700]
+        "reload_entrances": [0x2f00, 0x1400, 0x1401, 0x1700], 
+        "id": 252,
     },
     "Woodland Tracks": {
         'classification': ItemClassification.progression,
@@ -1798,7 +2032,8 @@ ITEMS_DATA |= {
         "item_groups": ["Tracks: Wooded Temple Tracks", "Tracks: Forest Glyph", "Tracks: W Wooded Temple",
                         "Tracks: W Castle Town",
                         "Thematic Track Groupings"],
-        "reload_entrances": [0x2f00],
+        "reload_entrances": [0x2f00], 
+        "id": 253,
     },
     "Borderlands Tracks": {
         'classification': ItemClassification.progression,
@@ -1806,7 +2041,8 @@ ITEMS_DATA |= {
         "value": 0x0b,
         'model': "Snow Glyph",
         "item_groups": ["Tracks: N Castle Town", "Tracks: Snow Realm Bridge", "Tracks: W Wooded Temple",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"], 
+        "id": 254,
     },
     "Coastal Tracks": {
         'classification': ItemClassification.progression,
@@ -1816,7 +2052,8 @@ ITEMS_DATA |= {
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Ocean Glyph", "Tracks: E Mayscore Bridge", "Tracks: Forest Realm SE Portal",
                         "Tracks: Forest Realm Ocean Shortcut",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"], 
+        "id": 255,
     },
     "Pirate Tracks": {
         'classification': ItemClassification.progression,
@@ -1825,7 +2062,8 @@ ITEMS_DATA |= {
         "set_bit": [(STAddr.tracks_0, 0x2), (STAddr.tracks_1, 0x80)],
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Forest Realm Ocean Shortcut", "Tracks: Pirate Hideout", "Tracks: Ocean Portal",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"], 
+        "id": 256,
     },
     "Ocean Tracks": {
         'classification': ItemClassification.progression,
@@ -1837,7 +2075,8 @@ ITEMS_DATA |= {
         "item_groups": ["Tracks: Ocean Source", "Tracks: Marine Temple Tracks", "Tracks: Lost at Sea Station",
                         "Tracks: Ocean Portal",
                         "Thematic Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700],
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 257,
     },
     "Island Tracks": {
         'classification': ItemClassification.progression,
@@ -1846,7 +2085,8 @@ ITEMS_DATA |= {
         "set_bit": [(STAddr.tracks_1, 0x40), (STAddr.tracks_2, 0x1)],
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Lost at Sea Station", "Tracks: Ocean Glyph", "Tracks: Pirate Hideout",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"], 
+        "id": 258,
     },
     "Valley Tracks": {
         'classification': ItemClassification.progression,
@@ -1855,7 +2095,8 @@ ITEMS_DATA |= {
         "set_bit": [(STAddr.tracks_2, 0x18)],
         'model': "Fire Glyph",
         "item_groups": ["Tracks: Disorientation Station", "Tracks: Fire Glyph", "Tracks: Snow Realm Gorge",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"], 
+        "id": 259,
     },
     "Mountain Tracks": {
         'classification': ItemClassification.progression,
@@ -1865,7 +2106,8 @@ ITEMS_DATA |= {
         'model': "Fire Glyph",
         "item_groups": ["Tracks: Mountain Temple Tracks", "Tracks: Ends of the Earth", "Tracks: Dark Ore Mine",
                         "Tracks: Desert Temple Tracks",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"], 
+        "id": 260,
     },
     "Arid Tracks": {
         'classification': ItemClassification.progression,
@@ -1876,7 +2118,8 @@ ITEMS_DATA |= {
         "item_groups": ["Tracks: Fire Source", "Tracks: Fire Realm Sand Portal", "Tracks: Sand Realm",
                         "Tracks: Ocean Portal", "Tracks: Sand Source",
                         "Thematic Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700],
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 261,
     },
     "Dune Tracks": {
         'classification': ItemClassification.progression,
@@ -1886,7 +2129,8 @@ ITEMS_DATA |= {
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Sand Realm", "Tracks: Desert Temple Tracks", "Tracks: Fire Realm Sand Portal",
                         "Tracks: Sand Source",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"], 
+        "id": 262,
     },
     "Tower Tracks": {
         'classification': ItemClassification.progression,
@@ -1896,7 +2140,8 @@ ITEMS_DATA |= {
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Forest Source", "Tracks: Snow Source", "Tracks: Ocean Source", "Tracks: Fire Source",
                         "Thematic Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700],
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 263,
     },
     "Completed Forest Glyph": {
         'classification': ItemClassification.progression,
@@ -1911,7 +2156,8 @@ ITEMS_DATA |= {
                         "Tracks: Forest Realm Ocean Shortcut", "Tracks: Forest Realm SE Portal",
                         "Tracks: E Mayscore Bridge",
                         "Completed Track Groupings"],
-        "reload_entrances": [0x2f000, 0x1400, 0x1401, 0x1700]
+        "reload_entrances": [0x2f000, 0x1400, 0x1401, 0x1700], 
+        "id": 264,
     },
     "Major Forest Tracks": {
         'classification': ItemClassification.progression,
@@ -1921,7 +2167,8 @@ ITEMS_DATA |= {
         'model': "Forest Glyph",
         "item_groups": ["Tracks: Forest Source", "Tracks: Wooded Temple Tracks", "Tracks: Forest Glyph",
                         "Major Track Groupings"],
-        "reload_entrances": [0x2f000, 0x1400, 0x1401, 0x1700]
+        "reload_entrances": [0x2f000, 0x1400, 0x1401, 0x1700], 
+        "id": 265,
     },
     "Minor Forest Tracks": {
         'classification': ItemClassification.progression,
@@ -1933,7 +2180,8 @@ ITEMS_DATA |= {
                         "Tracks: W Castle Town", "Tracks: N Castle Town", "Tracks: Snow Realm Bridge",
                         "Tracks: Forest Realm Ocean Shortcut", "Tracks: Forest Realm SE Portal",
                         "Tracks: E Mayscore Bridge",
-                        "Minor Track Groupings"]
+                        "Minor Track Groupings"], 
+        "id": 266,
     },
     "Completed Snow Glyph": {
         'classification': ItemClassification.progression,
@@ -1947,7 +2195,8 @@ ITEMS_DATA |= {
                         "Tracks: Slippery Station", "Tracks: Snowdrift Station", "Tracks: N Icy Spring",
                         "Tracks: Snow Realm Gorge",
                         "Completed Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700],
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 267,
     },
     "Major Snow Tracks": {
         'classification': ItemClassification.progression,
@@ -1957,7 +2206,8 @@ ITEMS_DATA |= {
         'model': "Snow Glyph",
         "item_groups": ["Tracks: Snow Source", "Tracks: Blizzard Temple Tracks", "Tracks: Snow Glyph",
                         "Major Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700],
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 268,
     },
     "Minor Snow Tracks": {
         'classification': ItemClassification.progression,
@@ -1968,7 +2218,8 @@ ITEMS_DATA |= {
         "item_groups": ["Tracks: W Wooded Temple", "Tracks: N Castle Town", "Tracks: Snow Realm Bridge",
                         "Tracks: Slippery Station", "Tracks: Snowdrift Station", "Tracks: N Icy Spring",
                         "Tracks: Snow Realm Gorge",
-                        "Minor Track Groupings"]
+                        "Minor Track Groupings"], 
+        "id": 269,
     },
     "Completed Ocean Glyph": {
         'classification': ItemClassification.progression,
@@ -1979,10 +2230,11 @@ ITEMS_DATA |= {
                     (STAddr.sources, 0x40), (STAddr.adv_flags_9, 0x40)],
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Ocean Source", "Tracks: Marine Temple Tracks", "Tracks: Ocean Glyph",
-                        "Tracks: Forest Realm Ocean Shortcut", "Tracks: Ocean Portal", 
-                        "Tracks: Lost at Sea Station", "Tracks: Pirate Hideout",  
+                        "Tracks: Forest Realm Ocean Shortcut", "Tracks: Ocean Portal",
+                        "Tracks: Lost at Sea Station", "Tracks: Pirate Hideout",
                         "Completed Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700],
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 270,
     },
     "Major Ocean Tracks": {
         'classification': ItemClassification.progression,
@@ -1993,7 +2245,8 @@ ITEMS_DATA |= {
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Ocean Source", "Tracks: Marine Temple Tracks", "Tracks: Ocean Glyph",
                         "Major Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700],
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 271,
     },
     "Minor Ocean Tracks": {
         'classification': ItemClassification.progression,
@@ -2003,7 +2256,8 @@ ITEMS_DATA |= {
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Forest Realm Ocean Shortcut", "Tracks: Ocean Portal",
                         "Tracks: Lost at Sea Station", "Tracks: Pirate Hideout",
-                        "Minor Track Groupings"]
+                        "Minor Track Groupings"], 
+        "id": 272,
     },
     "Completed Fire Glyph": {
         'classification': ItemClassification.progression,
@@ -2017,7 +2271,8 @@ ITEMS_DATA |= {
                         "Tracks: Dark Ore Mine", "Tracks: Fire Realm Sand Portal",
                         "Tracks: Snow Realm Gorge",
                         "Completed Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700],
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 273,
     },
     "Major Fire Tracks": {
         'classification': ItemClassification.progression,
@@ -2027,7 +2282,8 @@ ITEMS_DATA |= {
         'model': "Fire Glyph",
         "item_groups": ["Tracks: Fire Source", "Tracks: Mountain Temple Tracks", "Tracks: Fire Glyph",
                         "Major Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700],
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 274,
     },
     "Minor Fire Tracks": {
         'classification': ItemClassification.progression,
@@ -2039,7 +2295,8 @@ ITEMS_DATA |= {
                         "Tracks: Dark Ore Mine", "Tracks: Fire Realm Sand Portal",
                         "Tracks: Snow Realm Gorge",
                         "Minor Track Groupings"],
-        "reload_entrances": [0x1400, 0x1401, 0x1700],
+        "reload_entrances": [0x1400, 0x1401, 0x1700], 
+        "id": 275,
     },
     "Completed Desert Tracks": {
         'classification': ItemClassification.progression,
@@ -2049,7 +2306,8 @@ ITEMS_DATA |= {
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Sand Source", "Tracks: Desert Temple Tracks", "Tracks: Sand Realm",
                         "Tracks: Dark Ore Mine", "Tracks: Fire Realm Sand Portal",
-                        "Completed Track Groupings"]
+                        "Completed Track Groupings"], 
+        "id": 276,
     },
     "Major Desert Tracks": {
         'classification': ItemClassification.progression,
@@ -2058,7 +2316,8 @@ ITEMS_DATA |= {
         "set_bit": [(STAddr.rail_restorations, 0x20)],
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Sand Source", "Tracks: Desert Temple Tracks", "Tracks: Sand Realm",
-                        "Major Track Groupings"]
+                        "Major Track Groupings"], 
+        "id": 277,
     },
     "Minor Desert Tracks": {
         'classification': ItemClassification.progression,
@@ -2066,15 +2325,15 @@ ITEMS_DATA |= {
         "value": 0x6,
         'model': "Fire Glyph",
         "item_groups": ["Tracks: Dark Ore Mine", "Tracks: Fire Realm Sand Portal",
-                        "Minor Track Groupings"]
+                        "Minor Track Groupings"], 
+        "id": 278,
     },
     "Keyring (ToS 3)": {
-        'dummy': True  # Used to prevent a crash on opening boss door on 10F
+        'dummy': True,  # Used to prevent a crash on opening boss door on 10F
+        "id": 279,
     }
 
 }
-
-
 
 ITEM_GROUPS: dict[str, set[str]] = {}
 
@@ -2085,15 +2344,18 @@ for i, k in enumerate(ITEMS_DATA.items()):
     for group in item_data.get("item_groups", []):
         ITEM_GROUPS.setdefault(group, set()).add(item_name)
 
-
 # Combo Item Groups
 ITEM_GROUPS["Rupee Items"] = ITEM_GROUPS["Small Rupees"] | ITEM_GROUPS["Big Rupees"]
-ITEM_GROUPS["Uncommon Plus Treasure"] = ITEM_GROUPS["Uncommon Treasures"] | ITEM_GROUPS["Rare Treasures"] | ITEM_GROUPS["Super Rare Treasures"]
+ITEM_GROUPS["Uncommon Plus Treasure"] = ITEM_GROUPS["Uncommon Treasures"] | ITEM_GROUPS["Rare Treasures"] | ITEM_GROUPS[
+    "Super Rare Treasures"]
 ITEM_GROUPS["All Treasures"] = ITEM_GROUPS["Uncommon Plus Treasure"] | ITEM_GROUPS["Common Treasures"]
-ITEM_GROUPS["Rabbits"] = ITEM_GROUPS["Grass Rabbits"] | ITEM_GROUPS["Snow Rabbits"] | ITEM_GROUPS["Ocean Rabbits"] | ITEM_GROUPS["Mountain Rabbits"] | ITEM_GROUPS["Sand Rabbits"]
+ITEM_GROUPS["Rabbits"] = ITEM_GROUPS["Grass Rabbits"] | ITEM_GROUPS["Snow Rabbits"] | ITEM_GROUPS["Ocean Rabbits"] | \
+                         ITEM_GROUPS["Mountain Rabbits"] | ITEM_GROUPS["Sand Rabbits"]
 ITEM_GROUPS["Tears of Light"] = ITEM_GROUPS["Big Tears of Light"] | ITEM_GROUPS["Small Tears of Light"]
-ITEM_GROUPS["Basic Tracks"] = ITEM_GROUPS["Misc Tracks"] | ITEM_GROUPS["Restoration Tracks"] | ITEM_GROUPS["Sources"] | ITEM_GROUPS["Glyphs"]
-ITEM_GROUPS["Medium Track Groupings"] = ITEM_GROUPS["Major Track Groupings"] | ITEM_GROUPS["Minor Track Groupings"] | ITEM_GROUPS["Thematic Track Groupings"]
+ITEM_GROUPS["Basic Tracks"] = ITEM_GROUPS["Misc Tracks"] | ITEM_GROUPS["Restoration Tracks"] | ITEM_GROUPS["Sources"] | \
+                              ITEM_GROUPS["Glyphs"]
+ITEM_GROUPS["Medium Track Groupings"] = ITEM_GROUPS["Major Track Groupings"] | ITEM_GROUPS["Minor Track Groupings"] | \
+                                        ITEM_GROUPS["Thematic Track Groupings"]
 ITEM_GROUPS["Big Track Groupings"] = ITEM_GROUPS["Medium Track Groupings"] | ITEM_GROUPS["Completed Track Groupings"]
 ITEM_GROUPS["Small Track Groupings"] = ITEM_GROUPS["Medium Track Groupings"] | ITEM_GROUPS["Basic Tracks"]
 ITEM_GROUPS["Custom Track Groupings"] = ITEM_GROUPS["Big Track Groupings"]
@@ -2101,14 +2363,14 @@ ITEM_GROUPS["All Rails"] = ITEM_GROUPS["Rail Items"] | ITEM_GROUPS["Custom Track
 ITEM_GROUPS["Rupee Pool Items"] = ITEM_GROUPS["Uncommon Plus Treasure"] | ITEM_GROUPS["Big Rupees"]
 ITEM_GROUPS["Filler Item Pool"] = ITEM_GROUPS["Potions"] | ITEM_GROUPS["Small Rupees"] | ITEM_GROUPS["Common Treasures"]
 
-ITEM_GROUPS["Dungeon Keys"] = ITEM_GROUPS["Small Keys"] | ITEM_GROUPS ["Boss Keys"] | ITEM_GROUPS["Keyrings"]
+ITEM_GROUPS["Dungeon Keys"] = ITEM_GROUPS["Small Keys"] | ITEM_GROUPS["Boss Keys"] | ITEM_GROUPS["Keyrings"]
 ITEM_GROUPS["All Keys"] = ITEM_GROUPS["Dungeon Keys"] | ITEM_GROUPS["Misc Keys"]
 
 ITEMS: dict[str, "STItem"] = {}
 STItem.all_item_groups = ITEM_GROUPS
 for i, k in enumerate(ITEMS_DATA.items()):
     item_name, item_data = k
-    item_data["id"] = i+1
+    item_data["id"] = i + 1
     ITEMS[item_name] = STItem(item_name, item_data, ITEMS)
 
 # track_groups = {t: g for t, g in ITEM_GROUPS.items() if t.startswith("Tracks:")}

--- a/worlds/tloz_st/data/Items.py
+++ b/worlds/tloz_st/data/Items.py
@@ -35,7 +35,7 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         "model": "Sword"
     },
     "Shield": {
-        'classification': ItemClassification.progression,
+        'classification': ItemClassification.progression_deprioritized,
         'address': STAddr.items_2,
         'value': 0x01,
         'item_groups': ["Equipment"],
@@ -260,43 +260,52 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'address': STAddr.adv_flags_3,
         'value': 0x80,
         'item_groups': ["Train Items"],
-        'model': "Large Bomb Bag"
+        'model': "Large Bomb Bag",
+        "reload_entrances": [0x2F00]
     },
     "Portal Unlock: Hyrule Castle to Anouki Village": {
         'classification': ItemClassification.progression,
         # 'address': 0x265744,
         # 'value': 0x08,
         'item_groups': ["Portal Unlocks", "North Forest Portal", "N Forest Portal", "Anouki Portal", "SW Snow Portal"],
+        "reload_entrances": [0x400, 0x500],
     },
     "Portal Unlock: Trading Post to E Snow Realm": {
         'classification': ItemClassification.progression,
         # 'address': 0x265744,
         # 'value': 0x40,
         'item_groups': ["Portal Unlocks"],
+        "reload_entrances": [0x400, 0x500],
     },
     "Portal Unlock: Desert Temple to Sand Realm": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
+        "reload_entrances": [0x600],
     },
     "Portal Unlock: Sand Valley to Marine Temple": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
+        "reload_entrances": [0x600, 0x700],
     },
     "Portal Unlock: Forest Cave to Goron Village": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
+        "reload_entrances": [0x400, 0x700],
     },
     "Portal Unlock: Icy Spring to Mountain Temple": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
+        "reload_entrances": [0x500, 0x700],
     },
     "Portal Unlock: Mayscore to Ocean Portal Tracks": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
+        "reload_entrances": [0x400, 0x600],
     },
     "Portal Unlock: Snow Bridge to Island Sanctuary": {
         'classification': ItemClassification.progression,
         'item_groups': ["Portal Unlocks"],
+        "reload_entrances": [0x500, 0x600],
     },
 
     # ========== Rail Maps ============
@@ -307,6 +316,7 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x80,
         'item_groups': ["Glyphs", "Rail Items", "Forest Tracks", "Major Forest Tracks", "Tracks: Forest Glyph"],
         'model': "Forest Glyph 2",
+        "reload_entrances": [0x2F00],
     },
     "Snow Glyph": {
         'classification': ItemClassification.progression,
@@ -565,6 +575,7 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'set_bit': [[STAddr.source_rails, 2]],
         'item_groups': ["Rail Items", "Sources", "Forest Tracks", "Major Forest Tracks", "Tracks: Forest Source"],
         'model': "Forest Glyph",
+        "reload_entrances": [0x1400, 0x1401, 0x1700],
     },
     "Snow Source": {
       'classification': ItemClassification.progression,
@@ -573,6 +584,7 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'set_bit': [[STAddr.source_rails, 4]],
         'item_groups': ["Rail Items", "Sources", "Snow Tracks", "Major Snow Tracks", "Tracks: Snow Source"],
         'model': "Snow Glyph",
+        "reload_entrances": [0x1400, 0x1401, 0x1700]
     },
     "Ocean Source": {
       'classification': ItemClassification.progression,
@@ -581,6 +593,7 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'set_bit': [[STAddr.source_rails, 8], (STAddr.adv_flags_9, 0x40)],
         'item_groups': ["Rail Items", "Sources", "Ocean Realm Tracks", "Major Ocean Tracks", "Tracks: Ocean Source"],
         'model': "Ocean Glyph",
+        "reload_entrances": [0x1400, 0x1401, 0x1700]
     },
     "Fire Source": {
       'classification': ItemClassification.progression,
@@ -589,6 +602,7 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'set_bit': [[STAddr.source_rails, 0x10]],
         'item_groups': ["Rail Items", "Sources", "Fire Tracks", "Major Fire Tracks", "Tracks: Fire Source"],
         'model': "Fire Glyph",
+        "reload_entrances": [0x1400, 0x1401, 0x1700]
     },
     "Sand Source": {  # Only used for TEAO3 unlock?
         'classification': ItemClassification.progression,
@@ -1156,6 +1170,7 @@ ITEMS_DATA |= {
         'classification': ItemClassification.progression,
         "address": STAddr.tears_of_light,
         'value': 1,
+        "tags": ["always_process"],
         'item_groups': ["Tears of Light", "Small Tears of Light"],
         'model': "Tear of Light"
     },
@@ -1179,6 +1194,7 @@ ITEMS_DATA |= {
         'classification': ItemClassification.progression,
         "address": STAddr.tears_of_light,
         "rooms": [7, 8, 9, 0xa, 0x15, 0x16, 0x2A],
+        "tags": ["always_process"],
         'item_groups': ["Unique Tears of Light", "Small Tears of Light"],
         'model': "Tear of Light"
     },
@@ -1186,6 +1202,7 @@ ITEMS_DATA |= {
         'classification': ItemClassification.progression,
         "address": STAddr.tears_of_light,
         "rooms": [0xc, 0xd, 0xe, 0xf, 0x10],
+        "tags": ["always_process"],
         'item_groups': ["Unique Tears of Light", "Small Tears of Light"],
         'model': "Tear of Light"
     },
@@ -1193,12 +1210,14 @@ ITEMS_DATA |= {
         'classification': ItemClassification.progression,
         "address": STAddr.tears_of_light,
         "rooms": [0x11, 0x12, 0x13, 0x14, 0x17, 0x18],
+        "tags": ["always_process"],
         'item_groups': ["Unique Tears of Light", "Small Tears of Light"],
         'model': "Tear of Light"
     },
     "Tear of Light (ToS 6)": {
         'classification': ItemClassification.progression,
         "address": STAddr.tears_of_light,
+        "tags": ["always_process"],
         "rooms": [0x1d, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x2c, 0x2d],
         'item_groups': ["Unique Tears of Light", "Small Tears of Light"],
         'model': "Tear of Light"
@@ -1339,13 +1358,15 @@ ITEMS_DATA |= {
         "classification": ItemClassification.progression,
         "dummy": True,
         'item_groups': ["Tower of Spirit Unlocks"],
-        "model": "Forest Glyph"
+        "model": "Forest Glyph",
+        "reload_entrances": [0x400, 0x500, 0x600, 0x700],
     },
     "Progressive ToS Section": {
         "classification": ItemClassification.progression,
         "dummy": True,
         'item_groups': ["Tower of Spirit Unlocks"],
-        "model": "Forest Glyph"
+        "model": "Forest Glyph",
+        "reload_entrances": [0x400, 0x500, 0x600, 0x700],
     },
     # Overworld eventy things
     "Repair Trading Post Bridge": {
@@ -1572,139 +1593,139 @@ ITEMS_DATA |= {
 
     # Stamps
     "Stamp: Castle Town": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 1,
         "model": "Stamp Book"
     },
     "Stamp: Outset Village": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 2,
         "model": "Stamp Book"
     },
     "Stamp: Mayscore": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 3,
         "model": "Stamp Book"
     },
     "Stamp: Woodland Sanctuary": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 4,
         "model": "Stamp Book"
     },
     "Stamp: Anouki Village": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 5,
         "model": "Stamp Book"
     },
     "Stamp: Snowfall Sanctuary": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 6,
         "model": "Stamp Book"
     },
     "Stamp: Papuzia Village": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 7,
         "model": "Stamp Book"
     },
     "Stamp: Island Sanctuary": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 8,
         "model": "Stamp Book"
     },
     "Stamp: Goron Village": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 9,
         "model": "Stamp Book"
     },
     "Stamp: Valley Sanctuary": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xA,
         "model": "Stamp Book"
     },
     "Stamp: Dune Sanctuary": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xB,
         "model": "Stamp Book"
     },
     "Stamp: Wooded Temple": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xC,
         "model": "Stamp Book"
     },
     "Stamp: Blizzard Temple": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xD,
         "model": "Stamp Book"
     },
     "Stamp: Marine Temple": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xE,
         "model": "Stamp Book"
     },
     "Stamp: Mountain Temple": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0xF,
         "model": "Stamp Book"
     },
     "Stamp: Desert Temple": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0x10,
         "model": "Stamp Book"
     },
     "Stamp: Pirate Hideout": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0x11,
         "model": "Stamp Book"
     },
     "Stamp: Trading Post": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0x12,
         "model": "Stamp Book"
     },
     "Stamp: Icy Spring": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0x13,
         "model": "Stamp Book"
     },
     "Stamp: Tower of Spirits": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamps"],
         "value": 0,
         "model": "Stamp Book"
     },
     "Stamp Pack (2)": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamp Packs"],
         "value": 2,
         "model": "Stamp Book"
     },
     "Stamp Pack (3)": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamp Packs"],
         "value": 3,
         "model": "Stamp Book"
     },
     "Stamp Pack (4)": {
-        "classification": ItemClassification.progression,
+        "classification": ItemClassification.progression_deprioritized,
         "item_groups": ["Stamp Packs"],
         "value": 4,
         "model": "Stamp Book"
@@ -1743,7 +1764,8 @@ ITEMS_DATA |= {
         'model': "Snow Glyph",
         "item_groups": ["Tracks: Snow Source", "Tracks: N Castle Town", "Tracks: Blizzard Temple Tracks",
                         "Tracks: Snow Realm Gorge", "Tracks: N Icy Spring",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700]
     },
     "Blizzard Tracks": {
         'classification': ItemClassification.progression,
@@ -1753,7 +1775,8 @@ ITEMS_DATA |= {
         'model': "Snow Glyph",
         "item_groups": ["Tracks: Blizzard Temple Tracks", "Tracks: Snowdrift Station",
                         "Tracks: Slippery Station", "Tracks: Snow Source",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700]
     },
     "Castle Tracks": {
         'classification': ItemClassification.progression,
@@ -1763,7 +1786,8 @@ ITEMS_DATA |= {
         'model': "Forest Glyph",
         "item_groups": ["Tracks: N Castle Town", "Tracks: Forest Glyph", "Tracks: W Castle Town Tracks",
                         "Tracks: Forest Source",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"],
+        "reload_entrances": [0x2f00, 0x1400, 0x1401, 0x1700]
     },
     "Woodland Tracks": {
         'classification': ItemClassification.progression,
@@ -1773,7 +1797,8 @@ ITEMS_DATA |= {
         'model': "Forest Glyph",
         "item_groups": ["Tracks: Wooded Temple Tracks", "Tracks: Forest Glyph", "Tracks: W Wooded Temple",
                         "Tracks: W Castle Town",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"],
+        "reload_entrances": [0x2f00],
     },
     "Borderlands Tracks": {
         'classification': ItemClassification.progression,
@@ -1811,7 +1836,8 @@ ITEMS_DATA |= {
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Ocean Source", "Tracks: Marine Temple Tracks", "Tracks: Lost at Sea Station",
                         "Tracks: Ocean Portal",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700],
     },
     "Island Tracks": {
         'classification': ItemClassification.progression,
@@ -1849,7 +1875,8 @@ ITEMS_DATA |= {
         'model': "Fire Glyph",
         "item_groups": ["Tracks: Fire Source", "Tracks: Fire Realm Sand Portal", "Tracks: Sand Realm",
                         "Tracks: Ocean Portal", "Tracks: Sand Source",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700],
     },
     "Dune Tracks": {
         'classification': ItemClassification.progression,
@@ -1868,7 +1895,8 @@ ITEMS_DATA |= {
         "set_bit": [(STAddr.source_rails, 0x1e), (STAddr.adv_flags_9, 0x40)],
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Forest Source", "Tracks: Snow Source", "Tracks: Ocean Source", "Tracks: Fire Source",
-                        "Thematic Track Groupings"]
+                        "Thematic Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700],
     },
     "Completed Forest Glyph": {
         'classification': ItemClassification.progression,
@@ -1882,7 +1910,8 @@ ITEMS_DATA |= {
                         "Tracks: W Castle Town", "Tracks: N Castle Town", "Tracks: Snow Realm Bridge",
                         "Tracks: Forest Realm Ocean Shortcut", "Tracks: Forest Realm SE Portal",
                         "Tracks: E Mayscore Bridge",
-                        "Completed Track Groupings"]
+                        "Completed Track Groupings"],
+        "reload_entrances": [0x2f000, 0x1400, 0x1401, 0x1700]
     },
     "Major Forest Tracks": {
         'classification': ItemClassification.progression,
@@ -1891,7 +1920,8 @@ ITEMS_DATA |= {
         "set_bit": [(STAddr.rail_restorations, 2), (STAddr.source_rails, 2), (STAddr.sources, 0x10)],
         'model': "Forest Glyph",
         "item_groups": ["Tracks: Forest Source", "Tracks: Wooded Temple Tracks", "Tracks: Forest Glyph",
-                        "Major Track Groupings"]
+                        "Major Track Groupings"],
+        "reload_entrances": [0x2f000, 0x1400, 0x1401, 0x1700]
     },
     "Minor Forest Tracks": {
         'classification': ItemClassification.progression,
@@ -1911,21 +1941,23 @@ ITEMS_DATA |= {
         "value": 0x1,
         "set_bit": [(STAddr.tracks_1, 0x3f), (STAddr.tracks_2, 0x8),
                     (STAddr.rail_restorations, 4), (STAddr.source_rails, 4), (STAddr.sources, 0x20)],
-        'model': "Forest Glyph",
+        'model': "Snow Glyph",
         "item_groups": ["Tracks: Snow Source", "Tracks: Blizzard Temple Tracks", "Tracks: Snow Glyph",
                         "Tracks: W Wooded Temple", "Tracks: N Castle Town", "Tracks: Snow Realm Bridge",
                         "Tracks: Slippery Station", "Tracks: Snowdrift Station", "Tracks: N Icy Spring",
                         "Tracks: Snow Realm Gorge",
-                        "Completed Track Groupings"]
+                        "Completed Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700],
     },
     "Major Snow Tracks": {
         'classification': ItemClassification.progression,
         "address": STAddr.glyphs,
         "value": 0x1,
         "set_bit": [(STAddr.rail_restorations, 4), (STAddr.source_rails, 4), (STAddr.sources, 0x20)],
-        'model': "Forest Glyph",
+        'model': "Snow Glyph",
         "item_groups": ["Tracks: Snow Source", "Tracks: Blizzard Temple Tracks", "Tracks: Snow Glyph",
-                        "Major Track Groupings"]
+                        "Major Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700],
     },
     "Minor Snow Tracks": {
         'classification': ItemClassification.progression,
@@ -1949,7 +1981,8 @@ ITEMS_DATA |= {
         "item_groups": ["Tracks: Ocean Source", "Tracks: Marine Temple Tracks", "Tracks: Ocean Glyph",
                         "Tracks: Forest Realm Ocean Shortcut", "Tracks: Ocean Portal", 
                         "Tracks: Lost at Sea Station", "Tracks: Pirate Hideout",  
-                        "Completed Track Groupings"]
+                        "Completed Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700],
     },
     "Major Ocean Tracks": {
         'classification': ItemClassification.progression,
@@ -1959,14 +1992,15 @@ ITEMS_DATA |= {
                     (STAddr.sources, 0x40), (STAddr.adv_flags_9, 0x40)],
         'model': "Ocean Glyph",
         "item_groups": ["Tracks: Ocean Source", "Tracks: Marine Temple Tracks", "Tracks: Ocean Glyph",
-                        "Major Track Groupings"]
+                        "Major Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700],
     },
     "Minor Ocean Tracks": {
         'classification': ItemClassification.progression,
         "address": STAddr.tracks_0,
         "value": 0x2,
         "set_bit": [(STAddr.tracks_1, 0xc0), (STAddr.tracks_2, 0x1)],
-        'model': "Forest Glyph",
+        'model': "Ocean Glyph",
         "item_groups": ["Tracks: Forest Realm Ocean Shortcut", "Tracks: Ocean Portal",
                         "Tracks: Lost at Sea Station", "Tracks: Pirate Hideout",
                         "Minor Track Groupings"]
@@ -1982,7 +2016,8 @@ ITEMS_DATA |= {
                         "Tracks: Disorientation Station", "Tracks: Ends of the Earth",
                         "Tracks: Dark Ore Mine", "Tracks: Fire Realm Sand Portal",
                         "Tracks: Snow Realm Gorge",
-                        "Completed Track Groupings"]
+                        "Completed Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700],
     },
     "Major Fire Tracks": {
         'classification': ItemClassification.progression,
@@ -1991,7 +2026,8 @@ ITEMS_DATA |= {
         "set_bit": [(STAddr.rail_restorations, 0x10), (STAddr.source_rails, 0x10), (STAddr.sources, 0x80)],
         'model': "Fire Glyph",
         "item_groups": ["Tracks: Fire Source", "Tracks: Mountain Temple Tracks", "Tracks: Fire Glyph",
-                        "Major Track Groupings"]
+                        "Major Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700],
     },
     "Minor Fire Tracks": {
         'classification': ItemClassification.progression,
@@ -2002,7 +2038,8 @@ ITEMS_DATA |= {
         "item_groups": ["Tracks: Disorientation Station", "Tracks: Ends of the Earth",
                         "Tracks: Dark Ore Mine", "Tracks: Fire Realm Sand Portal",
                         "Tracks: Snow Realm Gorge",
-                        "Minor Track Groupings"]
+                        "Minor Track Groupings"],
+        "reload_entrances": [0x1400, 0x1401, 0x1700],
     },
     "Completed Desert Tracks": {
         'classification': ItemClassification.progression,

--- a/worlds/tloz_st/data/Locations.py
+++ b/worlds/tloz_st/data/Locations.py
@@ -2313,7 +2313,8 @@ LOCATIONS_DATA = {
         "vanilla_item": "Small Key (Mountain Temple)",
         "x_max": -45000,
         "z_max": -55000,
-        "dungeon": "Mountain Temple"
+        "dungeon": "Mountain Temple",
+        "delay_pickup": ["Mountain Temple 2F Stalfos"]
     },
     "Mountain Temple 2F Heatoise Chest": {
         "stage_id": 0x1C,
@@ -3252,6 +3253,7 @@ LOCATIONS_DATA |= {
         "location_groups": ["Portal Checks"],
         "conditional": True,
         "from_entrances": [0xFB, 0xB, 0x7],  # Only load when in right bit of track
+        "from_coords": {"x_min": 80000}
     },
     "Fire Realm Shoot Sand Portal": {
         "stage_id": 0x07,
@@ -4203,6 +4205,15 @@ LOCATIONS_DATA |= {
         "region_id": "tos 21f bombs",
         'dungeon': "ToS",
         "tos_section": 5,
+    },
+    "Mountain Temple 2F Stalfos": {  # Dummy location for stalfos treasure drop conflict
+        "stage_id": 0x1C,
+        "room_id": 0x6,
+        "region_id": "mtt 2f right",
+        "vanilla_item": "Treasure: Stalfos Skull",
+        "x_max": -45000,
+        "z_max": -55000,
+        "conditional": True
     },
 
 }

--- a/worlds/tloz_st/data/Locations.py
+++ b/worlds/tloz_st/data/Locations.py
@@ -734,7 +734,6 @@ LOCATIONS_DATA = {
         "region_id": "tos 14f phantom",
         'dungeon': "ToS",
         "tos_section": 4,
-        "conditional": "tears",
         "z_min": 15000,
         "x_min": 50000,
     },

--- a/worlds/tloz_st/data/LogicPredicates.py
+++ b/worlds/tloz_st/data/LogicPredicates.py
@@ -519,7 +519,7 @@ def st_mtt_center(state, player):
                 st_has_bombs(state, player),
                 all([
                     st_option_hard_logic(state, player),
-                    st_has_bow(state, player) or st_has_beam_sword(state, player)
+                    st_has_bow(state, player) or st_has_beam_sword(state, player) or st_has_whip(state, player)
                 ])
             ])
         ]),

--- a/worlds/tloz_st/data/ModelLookups.py
+++ b/worlds/tloz_st/data/ModelLookups.py
@@ -2242,6 +2242,7 @@ all_lookups: dict[str, dict[str, int]] = {
     "The Wind Waker": convert(tww),
     "Twilight Princess": convert(tp),
     "The Minish Cap": convert(tmc),
+    "Phantom Hourglass": convert(ph),
     "Skyward Sword": convert(ss),
     "A Link Between Worlds": convert(albw)
 }

--- a/worlds/tloz_st/docs/setup.md
+++ b/worlds/tloz_st/docs/setup.md
@@ -9,7 +9,8 @@
 
 ## Recommended Software
 
-* [Universal Tracker](https://github.com/FarisTheAncient/Archipelago/releases)
+* [Universal Tracker](https://github.com/FarisTheAncient/Archipelago/releases) (Includes a simple map tracker)
+* [Itemtracker](https://github.com/carrotinator/spirit-tracks-poptracker-ap) for [Poptracker](https://github.com/black-sliver/PopTracker) (still work in progress, currently only includes a manual rail and portal tracker)
 
 ## Setup
 
@@ -17,7 +18,7 @@
 2. Create a yaml settings file, and put it in the Archipelago directories 'players' folder. You can generate a template yaml with the archipelago launcher.
 3. Generate your game
 4. Host the game, either locally or via the archipelago web hosting service
-5. Open the 'generic bizhawk client' in Archipelago, and connect to the server
+5. Open the 'generic bizhawk client' in Archipelago, and connect to the server. There are currently bugs in the game, and launching the client from the debug launcher creates useful debug info in case you run into one. You can find `ArchipelagoLauncherDebug.exe` in your archipelago directory.
 6. Launch the vanilla game in bizhawk, and open the lua console. Add the 'connector_bizhawk_generic.lua' script that can be found in 'Archipelago\data\lua'. 
 7. You are now ready to play! Start a new savefile and go!
 
@@ -35,6 +36,9 @@ This also refills your ammo.
 ### What is my current goal?
 You can check your current goal and progress towards it at any time with the client command `/goal`
 
+### What is included in hard/glitched logic?
+Check the [Tricks and Skips guide](https://github.com/DayKat/spirit-tracks/blob/main/worlds/tloz_st/docs/tricks_and_skips.md)
+
 ### What is different from vanilla or has unintuitive requirements in vanilla?
 - If playing with randomized passengers, NPCs let you pick them up for quests once you have the rail holding their destination station. Exception being Alfonzo, who spawns in Hyrule Castle with the Snow Glyph.
 - Some minigames open with vanilla requirements. Hyrule sword game opens with Snow Source, Goron target range opens after removing the first lava in Goron village and each level of Take ‘em all on unlocks with forest-ocean-sand sources. Unlocking a higher level also unlocks the lower ones. 
@@ -46,6 +50,9 @@ You can check your current goal and progress towards it at any time with the cli
 - The Tower of Spirits summit counts as its own section for tower shuffle, and the stamp stand location there can’t be excluded or removed along with other sections. 
 - The blue warp through ToS 5 will always be open if ToS 5 is excluded, meaning you still need to fight Staven to check what’s on the other side.
 - Progressive tears of light with tower shuffle use the vanilla entrances to determine the order. So the order is entrance 1, e2 (forest source), e3 (snow source), e4 (ocean source), e5 (fire source), exit staven, enter altar in summit. Even if the summit is randomized to be your first section, the progressive tears for the section within will be last in the order.
+
+### Does it work with dpad/controller patches?
+Only some of them. [This one](https://github.com/StraDaMa/Legend-of-Zelda-Spirit-Tracks-D-Pad-Patch) probably works.
 
 ### Who made this?
 - The project is built upon @[Carrotinator](https://github.com/carrotinator)'s [Phantom Hourglass AP](https://github.com/carrotinator/Archipelago) implementation, which in turn is built upon @Dinopony and @Ishigh's [Oracle of Seasons AP](https://github.com/Dinopony/ArchipelagoOoS).

--- a/worlds/tloz_st/docs/tricks_and_skips.md
+++ b/worlds/tloz_st/docs/tricks_and_skips.md
@@ -1,0 +1,100 @@
+# Spirit Tracks AP Tricks and Skips
+A list of all tricks included in the randomizer, with video links when available, and what logic difficulty they're classified as.
+A lot of hard logic stuff is just annoying, slow, random, requires damage boosting or skips part of a puzzle.
+
+## Castle Town/Hyrule Castle
+- Pushing the block in Tunnel to Tower wihout items (enemies are annoying) (Hard Logic)
+- You can use the whirlwind to know a cucco off the left house roof without song of birds [(Hard Logic)](https://youtu.be/5l6n-FZas70?si=qgaoQXScE_IfO0Dn&t=922)
+
+## Tower of Spirits
+
+### ToS 1
+- On 2F, you can roll into the south push block while zelda is pushing it into a wall to clip on top of it letting you climb onto zelda and get 2 chests without whirlwind [(Glitched Logic)](https://www.twitch.tv/twilightwakeroftime/clip/PopularCalmWoodpeckerKreygasm-2TqxtqMHQYPB6YFl)
+
+### ToS 4
+- You can skip the left key door on 14F by throwing the boomerang over the wall [(Glitched Logic)](https://youtu.be/v8p2yiB9eLw?si=B2fan6qrYe9NSMhV)
+- You can throw a knife to hit switches through doors on 14F (Glitched Logic)
+  - or use it to skip zelda [(Useless until we get internal dungeon rando)](https://youtu.be/uiz9YotHEWI?si=zdL5dWqIUa4oJvBx)
+- You can skip part of the left puzzle on 15F with a jumpslash bomb boost over the pit. This saves needing range to hit the switch [(Glitched Logic)](https://youtu.be/UZYqF8Tlw9g)
+  - You can also bomb boost off of Zelda [(TAS only?)](https://youtu.be/_v0IYUd2GHg?si=ZfKOOEwn0KLkYf4Z)
+  - Or use a phantom eye [(Not implemented)](https://youtu.be/lPYuZ9hoHxU?si=3EpWCRm7Fnb-OUnK)
+- you can skip the key door on 15F with a bomb boost off a block clip [(not implemented)](https://youtu.be/OTk27mtYFOQ?si=G50e2lvxXmh21wgR)
+
+### ToS 5
+- You can block clip to skip the block pushing puzzle in the middle of 18F [(Doesn't affect logic)](https://youtu.be/ycAbPvbO-io?si=MXOnRH2pwCt4k1PE)
+- You can hit the left arrow repeater on SW 20F from the switch top left (doesn't affect logic)
+  - You can rotate the sw repeater with boomerang or beam sword (Normal Logic)
+  - you can jump on the pushable block in that room to reach it with whip [(Hard logic)](https://youtu.be/19uhFu6TVK8)
+  - you can have zelda push you on the block to hit it with sword [(Hard Logic)](https://youtu.be/WfvvQ5-4S8c)
+- you can also despawn the arrow to shoot through the door without standing on the switch [(doesn't affect logic)](https://youtu.be/Sq_2khf6uYU?si=-TGAk91aqof6RXjy)
+- You can trigger the boss key without zelda with the whirlwind if boss keys are randomize (doesn't affect logic)
+- You can skip the boss key on 22F [(not implemented)](https://youtu.be/5MhTFeCp2WA?si=dPyOWMlVbhEgAvLS)
+
+### ToS 6
+- You can skip 2 keys and the massive 26F puzzle by clipping out of bounds [(Glitched Logic)](https://youtu.be/VxWu4-u3dcE?si=yYKxx9PM_p0N1pyC)
+- You can arrow despawn to hit the 26F NE eye switch early [(Doesn't affect logic)](https://youtu.be/yQJNhb9AHAo?si=I1WYmYj0AVhsB_aU)
+- You can skip the warp phantom on the left side of 26F [(Doesn't affect logic)](https://youtu.be/yiQd0S_KpKA)
+
+## Wooded Temple
+- You can damage boost through the poison to reach the stamp stand and switch on 1F (Hard logic)
+- You can damage boost through the poison to reach the chest on Right 2F (Hard logic)
+- You can damage boost through the poison to reach the switch and chest on SE 3F (Hard logic)
+
+## Anouki Village
+- You can skip the block pushing puzzle with a block clip (doesn't affect logic)
+
+## Icy Spring
+- You can reach icy spring early by picking up ferrus in Fire Realm with vanilla passengers, failing on purpose and clicking yes when the game asks you if you want to follow him. Exiting icy spring will take you back to the fire realm. (Not in logic due to repeatablility)
+
+## Blizzard Temple
+- you can block clip to skip the first block pushing puzzle (doesn't affect logic)
+- Killing the freezards in B1 without the boomerang logically requires:
+  - (Shield or Bow of Light) and any damage (Normal Logic)
+  - Any damage (Hard Logic)
+- You can trigger the boss key without doing the torch puzzle with the whirlwind if boss keys are randomize (doesn't affect logic)
+
+## Snowdrift Station
+- You can hit the switches with boomerang, bow (Normal Logic) or Beam Sword (Hard Logic)
+- To logically kill the freezards you need:
+  - (Shield or Bow of Light) and any damage (Normal Logic)
+  - any damage (Hard Logic)
+
+## Trading Post
+- You dig up the buriend chest in the NE cave without Song of Light (Hard Logic)
+
+## Papuzia Village
+- You can reach south papuzia without song of birds with good timing (Hard Logic)
+
+## Island Sanctuary
+- You can reach the S bird chest and the NW bird chest without Song of Birds (Hard Logic)
+- You can skip the cave to the north section with a well placed and timed song of birds [(Hard Logic)](https://youtu.be/4kzmcoe8vkk)
+
+## Marine Temple
+- You can damage boost through the boulders to reach the right side of 1F (Hard Logic)
+- You can trigger the boss key location on 6F if boss keys are randomized with the whirwind early (Hard Logic)
+- You can use a jumpslash bomb boost (with whirlwind) to damage boost across the gap to the boss key on 6F [(Glitched Logic)](https://youtu.be/LSim_sYBBw4)
+- Failing to take ferrus to the marine temple with vanilla passengers without access to icy spring can cause him to get stuck there. So don't fail. (Ferrus marine temple logically requires icy spring access)
+
+
+## Lost at Sea Station
+- You can dig up the buried chest without song of light (Hard Logic)
+- You can get on the bird to the cliff without Song of Birds (Hard Logic)
+- You can clear the wrecker phantom room without bombs (Hard Logic)
+
+## Mountain Temple
+- You can hit the timed switches behind the locked doors on 1F with:
+  - Boomerang or bombs (Normal Logic)
+  - Bow, Whip or Beam Sword (Hard Logic)
+- You can skip one of the keys by boomeranging over the wall from a high ledge [(Glitched Logic)](https://youtu.be/zoQGwgGQY_o?si=DKoy-zu2hmFhcjHj)
+  - You can also do this with bombs and whirlwind [(Doesn't affect logic)](https://youtu.be/VQJHLQS8eKk?si=vNwIBZbYQHEoVEYX)
+- You can skip both doors by going out of bounds with bombs [(Glitched Logic)](https://youtu.be/8BOmU_wpax8?si=B5ujxt_MugiLW1_9)
+
+## Disorientation Station
+- You can catch the bird without song of birds (Hard Logic)
+
+## Desert Temple
+- You can do a bomb boost to get out of bounds on B1 and skip the boss key [(Glitched Logic)](https://youtu.be/QCBSFibjfm0)
+
+## Overworld Rabbits
+- You can hit the SW Trading post rabbit without the Forest Realm SE Portal Tracks (Hard Logic)
+- You can hit certain rabbits in the blizzard without snow source to clear it by driving close to the void out zones (Hard Logic)


### PR DESCRIPTION
- added a tricks and skips doc
- fixed some unimplemented glitched logic in mountain temple
- added ph to model swaps (requires ph ap v8.7+)
- fixed vanilla tears of light option still creating locations
- generalized reloading of dynamic entrances based on scene on getting items that change that, allowing immediate entry into previously blocked scenes without reloading.
- fixed blocked entrance text still showing after reloading dynamic entrances
- fixed buggy behaviour with tears from vanilla locations in ToS 3+
- changed itemclassification for stamps to progressive_deprioritized
- added a yaml option for swapping models of other Zelda game's items.
- locked item ids
- removed mountain temple b1 heatoise arena warp cause it risked locations becoming permanently missable
- Prevented random stalfos skull drops from triggering mountain temple 2F NW Chest early
- Filled in invisible staircases in ToS with source unlock option
- added coordinate support for dynamic requirements
- added coordinate check for opening the desert realm portals when coming from fire realm
- fixed snuglar locations not properly resetting
- made giving ice to kagoron connect the regions in UT even if out of logic