### PR TITLE
ST AP v7.5

### DIFF
--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -207,7 +207,6 @@ class SpiritTracksClient(DSZeldaClient):
         self.train_quick_station = True
         self.update_train_speed: bool = False
         self.train_speed = [-143, 0, 115, 193]
-        self.has_set_starting_train = False
         self.key_address = STAddr.small_keys
 
         self.hint_data = HINT_DATA
@@ -346,8 +345,6 @@ class SpiritTracksClient(DSZeldaClient):
 
     async def watched_intro_cs(self, ctx):
         watched_intro = await STAddr.watched_intro.read(ctx) & 1
-        if not watched_intro:
-            self.has_set_starting_train = False
         return watched_intro
 
     async def update_main_read_list(self, ctx: "BizHawkClientContext", stage: int, in_game=True):
@@ -1139,11 +1136,9 @@ class SpiritTracksClient(DSZeldaClient):
 
     async def process_hard_coded_rooms(self, ctx, current_scene):
         self.delay_room_action = 5
-        if current_scene == 0x2f00 and not self.has_set_starting_train:
-            # if self.location_name_to_id["Outset Bee Tree"] not in ctx.checked_locations:
-            #     print(f"Setting starting train")
+        if current_scene == 0x2f00 and not await STAddr.set_starting_train.read(ctx) & 4:
             await self.set_starting_train(ctx)
-            self.has_set_starting_train = True
+            await STAddr.set_starting_train.set_bits(ctx, 4)
         if self.save_ammo:
             await write_multiple(ctx, list(self.save_ammo.keys()), list(self.save_ammo.values()))
             self.save_ammo = None
@@ -1161,11 +1156,21 @@ class SpiritTracksClient(DSZeldaClient):
                 print(f"Has found location {data['location']}, deleting boss key")
                 await self.delete_boss_key(ctx)
             else:
-                pointer = await data["pointer"].read(ctx)
-                if 0x2000000 < pointer < 0x2400000:
+                if "pointer" in data:
+                    pointer = await data["pointer"].read(ctx)
+                    print(f"bk pointer: {data['pointer']} -> {hex(pointer)}")
+                else:
+                    actor_table = await STAddr.tos_actor_table_pointer_safe.read(ctx)
+                    offset = 1040 + 8  # start of table + tos bk index
+                    pointer_addr = Address.from_pointer(actor_table+offset, size=3)
+                    pointer = await pointer_addr.read(ctx)
+                    print(f"BK pointer from table read: {pointer_addr} -> {hex(pointer)} actor table: {actor_table}")
+
+                if pointer < 0x400000:
                     offset = 12 if self.current_stage == 0x1c else 8
-                    self.boss_key_read = Address.from_pointer(pointer+offset-0x2000000, size=4)
+                    self.boss_key_read = Address.from_pointer(pointer+offset, size=4)
                     self.boss_key_y = data["y"]
+                    print(f"BK Read: {self.boss_key_read}")
                 print(f"Loaded boss key data: {hex(pointer)} y: {self.boss_key_y}")
 
             # Open door
@@ -1290,7 +1295,7 @@ class SpiritTracksClient(DSZeldaClient):
 
 
     async def delete_boss_key(self, ctx):
-        pointer = await STAddr.boss_key_deletion_pointer.read(ctx) - 0x2000000
+        pointer = await STAddr.boss_key_deletion_pointer.read(ctx)
         print(f"Deleting boss key @ {hex(pointer)}")
         size, offset = 12, 0
         if self.current_stage == 0x1b:

--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -246,7 +246,7 @@ class SpiritTracksClient(DSZeldaClient):
             has_compass = "" if self.item_count(ctx, "Compass of Light") else "don't "
             logger.info(f"You need the Compass of Light to access the Dark Realm. You {has_compass}have it.")
         if slot_data["dark_realm_access"] in [1, 3]:
-            specific = "specific " if slot_data["require_specific_dungeons"] else ""
+            specific = "specific " if slot_data.get("require_specific_dungeons", False) else ""
             dungeon_locs = slot_data["required_dungeons"]
             has_locs = sum([1 for loc in ctx.checked_locations if loc in dungeon_locs])
             logger.info(

--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -712,8 +712,13 @@ class SpiritTracksClient(DSZeldaClient):
         print(f"Reseting treasure models")
         await bizhawk.write(ctx.bizhawk_ctx, write_list)
 
-    async def swap_models(self, ctx, locations: list, generic_model=0x59637266, treasure_mode=False):
+    async def swap_models(self, ctx, locations: list, treasure_mode=False):
         print(f"\tMultiple locations: {locations}")
+        generic_model = [
+            ITEM_MODEL_LOOKUP["Force Gem 17"].value,
+            ITEM_MODEL_LOOKUP["Letter"].value,
+            ITEM_MODEL_LOOKUP["Gold Rupee"].value,
+        ][ctx.slot_data.get("multiworld_item_default_models", 0)]
         item_location_check = {}  # dict of item to location id for what location determines the model
         item_priority = {}
         for loc_name in locations:

--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -574,10 +574,13 @@ class SpiritTracksClient(DSZeldaClient):
         if (item_name.startswith("Boss Key") or
             (item_name.startswith("Keyring") and ctx.slot_data["big_keyrings"])
         ) and self.current_scene in BOSS_KEY_DATA:
-            data = BOSS_KEY_DATA[self.current_scene]
-            if data["dungeon"] in item_name and (self.current_scene & 0xff00 != 0x1300 or self.location_name_to_id[data["location"]] in ctx.checked_locations):
-                print(f"Opening boss door for {hex(self.current_scene)}")
-                await data["door"].overwrite(ctx, 3)
+            if self.current_stage == 0x13:
+                await self.open_tos_boss_door(ctx, self.current_scene)
+            else:
+                data = BOSS_KEY_DATA[self.current_scene]
+                if data["dungeon"] in item_name and (self.current_scene & 0xff00 != 0x1300 or self.location_name_to_id[data["location"]] in ctx.checked_locations):
+                    print(f"Opening boss door for {hex(self.current_scene)}")
+                    await data["door"].overwrite(ctx, 3)
 
     async def process_on_room_load(self, ctx, current_scene, read_result: dict):
         await self.update_treasure_tracker(ctx, "room_load")
@@ -1139,6 +1142,14 @@ class SpiritTracksClient(DSZeldaClient):
         print(f"Setting starting train {res}")
         await bizhawk.write(ctx.bizhawk_ctx, res)
 
+    async def get_tos_bk_pointer(self, ctx) -> tuple[Address, int]:
+        actor_table = await STAddr.tos_actor_table_pointer_safe.read(ctx)
+        offset = 1040 + 8  # start of table + tos bk index
+        pointer_addr = Address.from_pointer(actor_table + offset, size=3)
+        pointer = await pointer_addr.read(ctx)
+        print(f"BK pointer from table read: {pointer_addr} -> {hex(pointer)} actor table: {actor_table}")
+        return pointer_addr, pointer
+
     async def process_hard_coded_rooms(self, ctx, current_scene):
         self.delay_room_action = 5
         if current_scene == 0x2f00 and not await STAddr.set_starting_train.read(ctx) & 4:
@@ -1165,11 +1176,7 @@ class SpiritTracksClient(DSZeldaClient):
                     pointer = await data["pointer"].read(ctx)
                     print(f"bk pointer: {data['pointer']} -> {hex(pointer)}")
                 else:
-                    actor_table = await STAddr.tos_actor_table_pointer_safe.read(ctx)
-                    offset = 1040 + 8  # start of table + tos bk index
-                    pointer_addr = Address.from_pointer(actor_table+offset, size=3)
-                    pointer = await pointer_addr.read(ctx)
-                    print(f"BK pointer from table read: {pointer_addr} -> {hex(pointer)} actor table: {actor_table}")
+                    pointer_addr, pointer = await self.get_tos_bk_pointer(ctx)
 
                 if pointer < 0x400000:
                     offset = 12 if self.current_stage == 0x1c else 8
@@ -1302,15 +1309,12 @@ class SpiritTracksClient(DSZeldaClient):
     async def delete_boss_key(self, ctx):
         pointer = await STAddr.boss_key_deletion_pointer.read(ctx)
         print(f"Deleting boss key @ {hex(pointer)}")
-        size, offset = 12, 0
+        size, offset = BOSS_KEY_DATA[self.current_scene].get("deletion_data", (12, 0))
         if self.current_stage == 0x1b:
             pointer += 44  # Ocean temple bk does not load into the first slot in memory
             await Address.from_pointer(pointer+60, 4).overwrite(ctx, 0)  # also needs this to not crash
-            size = 8
-        if self.current_stage == 0x1D:
-            size, offset = 4, 8
-        if self.current_stage == 0x1C:
-            size, offset = 4, 64
+        if self.current_stage == 0x13:
+            pointer, _ = await self.get_tos_bk_pointer(ctx)
         deletion_address = Address.from_pointer(pointer+offset, size)
         print(f"Deleting boss key @ {deletion_address} size {size}")
         # print(f"Deleting boss key @ {STAddr.boss_key_deletion}")

--- a/worlds/tloz_st/Options.py
+++ b/worlds/tloz_st/Options.py
@@ -670,6 +670,21 @@ class SpiritTracksZeldaModelSwaps(Toggle):
     display_name = "Multiworld Item Model Swaps"
     default = 1
 
+class SpiritTracksMultiworldItemModel(Choice):
+    """
+    What unknown items from other worlds show up as.
+    Known items still change to their closest match if model swaps are enabled.
+    Revealed Traps always show up as skulls.
+    - force_gems: Foreign items show up as force gems.
+    - letters: Foreign items show up as letters.
+    - rupees: Foreign items show up as rupees. Gold for progression, blue for useful, green for filler.
+    """
+    display_name = "Multiworld Item Default Model"
+    option_force_gems = 0
+    option_letters = 1
+    option_rupees = 2
+    default = 0
+
 @dataclass
 class SpiritTracksOptions(PerGameCommonOptions):
     # Accessibility
@@ -745,6 +760,7 @@ class SpiritTracksOptions(PerGameCommonOptions):
     # Cosmetic
     starting_train: SpiritTracksStartingTrain
     multiworld_item_model_swaps: SpiritTracksZeldaModelSwaps
+    multiworld_item_default_models: SpiritTracksMultiworldItemModel
 
     # Generic
     start_inventory_from_pool: StartInventoryPool
@@ -813,7 +829,8 @@ st_option_groups = [
     ]),
     OptionGroup("Cosmetic Options", [
         SpiritTracksStartingTrain,
-        SpiritTracksZeldaModelSwaps
+        SpiritTracksZeldaModelSwaps,
+        SpiritTracksMultiworldItemModel
     ]),
     OptionGroup("Item & Location Options", [
         SpiritTracksRemoveItemsFromPool

--- a/worlds/tloz_st/Options.py
+++ b/worlds/tloz_st/Options.py
@@ -190,7 +190,7 @@ class SpiritTracksKeyrings(Choice):
     option_snurglar_only = 1
     option_all = 2
     option_random_mixed = 3
-    default = 1
+    default = 0
 
 class SpiritTracksBigKeyrings(Toggle):
     """

--- a/worlds/tloz_st/Subclasses.py
+++ b/worlds/tloz_st/Subclasses.py
@@ -37,7 +37,7 @@ async def receive_tos_key(client: "SpiritTracksClient", ctx, item: "STItem", rii
     return res
 
 async def receive_tear_of_light(client: "SpiritTracksClient", ctx, item: "STItem", rii):
-    if client.current_stage == 0x13 and client.last_vanilla_item[-1] != item.name:  # avoid calcing tears when vanilla
+    if client.current_stage == 0x13 and ctx.slot_data["randomize_tears"] != -1:  # avoid calcing tears when vanilla
         await client.set_tears(ctx)
 
     return []

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -1433,7 +1433,7 @@ class SpiritTracksWorld(WorldParent):
     def fill_slot_data(self) -> dict:
         options = ["goal", "compass_shard_count",
                    "logic", "cannon_logic",
-                   "exclude_dungeons", "exclude_sections",
+                   "exclude_dungeons", "exclude_sections", "require_specific_dungeons",
                    "keysanity", "randomize_boss_keys",
                    "big_keyrings",
                    "randomize_minigames", "minigame_hints",

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -1401,6 +1401,17 @@ class SpiritTracksWorld(WorldParent):
 
     def get_location_models(self):
         # get item placement models to send to client
+        default_models = [
+            [ITEM_MODEL_LOOKUP["Force Gem 17"].offset]*3,
+            [ITEM_MODEL_LOOKUP["Letter"].offset] * 3,
+            [
+                ITEM_MODEL_LOOKUP["Gold Rupee"].offset,
+                ITEM_MODEL_LOOKUP["Blue Rupee"].offset,
+                ITEM_MODEL_LOOKUP["Green Rupee"].offset
+            ]
+        ]
+        dmi = self.options.multiworld_item_default_models.value
+
         location_models = {}
         for loc in self.get_locations():
             item = loc.item
@@ -1418,14 +1429,13 @@ class SpiritTracksWorld(WorldParent):
                     location_models[loc_data['id']] = model
                     continue
 
-            if item.classification & ItemClassification.progression:
-                pass  # progression fallback is the default
-            elif item.classification & ItemClassification.trap:
+            if dmi in [2]:
+                if item.classification & ItemClassification.useful:
+                    location_models[loc_data['id']] = default_models[dmi][1]
+                elif item.classification & ItemClassification.filler:
+                    location_models[loc_data['id']] = default_models[dmi][2]
+            if item.classification & ItemClassification.trap:
                 location_models[loc_data['id']] = ITEM_MODEL_LOOKUP["Stalfos Skull"].offset
-            elif item.classification & ItemClassification.useful:
-                location_models[loc_data['id']] = ITEM_MODEL_LOOKUP["Blue Rupee"].offset
-            else:
-                location_models[loc_data['id']] = ITEM_MODEL_LOOKUP["Green Rupee"].offset
 
         return location_models
         # print(f"Location Models: {location_models}")
@@ -1443,7 +1453,7 @@ class SpiritTracksWorld(WorldParent):
                    "portal_behavior", "portal_checks",
                    "randomize_tears", "spirit_weapons", "tear_sections",
                    "dark_realm_access", "endgame_scope", "dungeons_required",
-                   "starting_train",
+                   "starting_train", "multiworld_item_default_models",
                    "randomize_stamps",
                    "tos_section_unlocks", "tos_unlock_base_item", "shuffle_tos_sections",
                    "shopsanity", "shop_hints", "rupee_farming_logic", "excess_random_treasure",

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -1401,15 +1401,13 @@ class SpiritTracksWorld(WorldParent):
 
     def get_location_models(self):
         # get item placement models to send to client
-        default_models = [
-            [ITEM_MODEL_LOOKUP["Force Gem 17"].offset]*3,
-            [ITEM_MODEL_LOOKUP["Letter"].offset] * 3,
-            [
+        default_models = {
+            2: [
                 ITEM_MODEL_LOOKUP["Gold Rupee"].offset,
                 ITEM_MODEL_LOOKUP["Blue Rupee"].offset,
                 ITEM_MODEL_LOOKUP["Green Rupee"].offset
             ]
-        ]
+        }
         dmi = self.options.multiworld_item_default_models.value
 
         location_models = {}

--- a/worlds/tloz_st/archipelago.json
+++ b/worlds/tloz_st/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Spirit Tracks",
-  "world_version": "0.7.4",
+  "world_version": "0.7.5",
   "authors": ["DayKat", "1313e", "Carrotinator", "TriforceDrummer", "Nepecute"],
   "minimum_ap_version": "0.6.0"
 }

--- a/worlds/tloz_st/data/Addresses.py
+++ b/worlds/tloz_st/data/Addresses.py
@@ -107,7 +107,7 @@ class STAddr:
     source_rails = Address(0x2653B8)
     key_storage_0 = Address(0x265784)
     key_storage_tos = Address(0x265785)
-    key_storage_2 = Address(0x265786)
+    key_storage_2 = set_starting_train = Address(0x265786)
 
     train_parts = Address(0x2653A8, size=4)
     equipped_engine = Address(0x265388, size=4)
@@ -129,15 +129,21 @@ class STAddr:
     cargo_count_1 = Address(0x2655e8)
 
     # Boss key pointers
-    boss_key_deletion_pointer = Address(0x265620, size=4)  # points to 3 references, and deleting then deletes the key.
+    boss_key_deletion_pointer = Address(0x265620, size=3)  # points to 3 references, and deleting then deletes the key.
     boss_key_deletion = Address(0x3251C0, size=12)
-    wt_bk_pointer = Address(0x3251C0, size=4)
-    bt_bk_pointer = Address(0x326C20, size=4)
-    oct_bk_pointer = Address(0x32520C, size=4)
-    mtt_bk_pointer = Address(0x32963C, size=4)
-    dt_bk_pointer = Address(0x3251C8, size=4)
-    tos3_bk_pointer = Address(0x332858, size=4)
-    tos_bk_pointer = Address(0x332818, size=4)
+    wt_bk_pointer = Address(0x3251C0, size=3)
+    bt_bk_pointer = Address(0x326C20, size=3)
+    oct_bk_pointer = Address(0x32520C, size=3)
+    mtt_bk_pointer = Address(0x32963C, size=3)
+    dt_bk_pointer = Address(0x3251C8, size=3)
+    tos3_bk_pointer = Address(0x332858, size=3)
+    tos5_bk_pointer = Address(0x332818, size=3)
+    tos_actor_table = Address(0x332810, size=3)
+    tos_bk_pointer = Address(0x332818, size=3)
+
+    tos_actor_table_pointer_0 = Address(0x3329C0, size=3)
+    tos_actor_table_pointer_1 = Address(0x329C3C, size=3)
+    tos_actor_table_pointer_safe = Address(0x25FA48, size=3)  # offset 1032 (header)/1040 (start of pointers)
 
     # Candidates for ToS 3 bk pointers
     # 332858

--- a/worlds/tloz_st/data/Constants.py
+++ b/worlds/tloz_st/data/Constants.py
@@ -538,19 +538,21 @@ BOSS_KEY_DATA = {
     },
     0x1309: {
         "y": 0,
-        "pointer": STAddr.tos3_bk_pointer,
+        # "pointer": STAddr.tos_actor_table_pointer_0,
         "location": "ToS 10F Boss Key",
         "door": STAddr.tos3_boss_door,
         "dungeon": "ToS 3",
-        "door_coords": 0xffff2ffc00000000fffffffc
+        "door_coords": 0xffff2ffc00000000fffffffc,
+        "key_coords": ""
     },
     0x1318: {
         "y": 0,
-        "pointer": STAddr.tos3_bk_pointer,
+        # "pointer": STAddr.tos_actor_table_pointer_0,
         "location": "ToS 22F Boss Key",
         "door": STAddr.tos5_boss_door,
         "dungeon": "ToS 5",
-        "door_coords": 0x4ffc000000000000affc
+        "door_coords": 0x4ffc000000000000affc,
+        "key_coords": ""
     },
 }
 

--- a/worlds/tloz_st/data/Constants.py
+++ b/worlds/tloz_st/data/Constants.py
@@ -520,21 +520,24 @@ BOSS_KEY_DATA = {
         "pointer": STAddr.oct_bk_pointer,
         "location": "Marine Temple 6F Boss Key",
         "door": STAddr.oct_boss_door,
-        "dungeon": "Marine Temple"
+        "dungeon": "Marine Temple",
+        "deletion_data": (8, 0)  # size, offset
     },
     0x1c04: {
         "y": -48000,
         "pointer": STAddr.mtt_bk_pointer,
         "location": "Mountain Temple B3 Boss Key",
         "door": STAddr.mtt_boss_door,
-        "dungeon": "Mountain Temple"
+        "dungeon": "Mountain Temple",
+        "deletion_data": (4, 64)
     },
     0x1d03: {
         "y": -2867,
         "pointer": STAddr.dt_bk_pointer,
         "location": "Desert Temple B1 Boss Key",
         "door": STAddr.dt_boss_door,
-        "dungeon": "Desert Temple"
+        "dungeon": "Desert Temple",
+        "deletion_data": (4, 8)
     },
     0x1309: {
         "y": 0,
@@ -543,7 +546,7 @@ BOSS_KEY_DATA = {
         "door": STAddr.tos3_boss_door,
         "dungeon": "ToS 3",
         "door_coords": 0xffff2ffc00000000fffffffc,
-        "key_coords": ""
+        "deletion_data": (4, 0)
     },
     0x1318: {
         "y": 0,
@@ -552,7 +555,7 @@ BOSS_KEY_DATA = {
         "door": STAddr.tos5_boss_door,
         "dungeon": "ToS 5",
         "door_coords": 0x4ffc000000000000affc,
-        "key_coords": ""
+        "deletion_data": (4, 0)
     },
 }
 

--- a/worlds/tloz_st/data/DynamicFlags.py
+++ b/worlds/tloz_st/data/DynamicFlags.py
@@ -1267,9 +1267,10 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
                      ],
         "unset_if_true": [(STAddr.adv_flags_b, 0x10),  # Remove finished quest flag
                         (STAddr.adv_flags_0, 0x20),  # Remove snow source
-                        (STAddr.adv_flags_1, 0x02),  # Remove btt
+                        (STAddr.adv_flags_1, 0x02),  # Remove btt and fire restoration
                         (STAddr.adv_flags_c, 0x08),  # Don't advance dialogue after btt
-                        (STAddr.adv_flags_4, 0x02)], # Remove Wagon, he gives ice hint
+                        (STAddr.adv_flags_4, 0x02),  # Remove Wagon, he gives ice hint
+                        (STAddr.adv_flags_3a, 0x40)], # unset brought noko to icyspring
         "reset_flags": ["Snow sanc Reset BTT", "RESET Add Snow Source", "RESET Wagon"]
     },
     "Anouki chief stop kofu": {
@@ -1568,7 +1569,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "on_scenes": [0x3500],
         "has_locations": ["Icy Spring Noko's Force Gem"],
         "has_slot_data": [("randomize_passengers", [2, 3])],
-        "set_if_true": [(STAddr.adv_flags_3a, 0x10)],
+        "set_if_true": [(STAddr.adv_flags_3a, 0x50)],
     },
     "No passengers icyspring": {
         "on_scenes": [0x3500],

--- a/worlds/tloz_st/data/Entrances.py
+++ b/worlds/tloz_st/data/Entrances.py
@@ -711,6 +711,15 @@ ENTRANCE_DATA = {
         "direction": EntranceGroups.INSIDE,
         "island": EntranceGroups.NONE
     },
+    "ToS Lobby Staircase": {
+        "return_name": "ToS Staircase Exit",
+        "exit_region": "tos",
+        "entrance": (0x14, 0x1, 0x1),  # Needs extra data for staircase side
+        "exit": (0x17, 0x0, 0x0),
+        "type": EntranceGroups.DUNGEON_ENTRANCE,
+        "direction": EntranceGroups.INSIDE,
+        "island": EntranceGroups.NONE
+    }
 
 
 }

--- a/worlds/tloz_st/data/Entrances.py
+++ b/worlds/tloz_st/data/Entrances.py
@@ -711,15 +711,15 @@ ENTRANCE_DATA = {
         "direction": EntranceGroups.INSIDE,
         "island": EntranceGroups.NONE
     },
-    "ToS Lobby Staircase": {
-        "return_name": "ToS Staircase Exit",
-        "exit_region": "tos",
-        "entrance": (0x14, 0x1, 0x1),  # Needs extra data for staircase side
-        "exit": (0x17, 0x0, 0x0),
-        "type": EntranceGroups.DUNGEON_ENTRANCE,
-        "direction": EntranceGroups.INSIDE,
-        "island": EntranceGroups.NONE
-    }
+    # "ToS Lobby Staircase": {
+    #     "return_name": "ToS Staircase Exit",
+    #     "entrance_region": "tos",
+    #     "entrance": (0x14, 0x1, 0x1),  # Needs extra data for staircase side
+    #     "exit": (0x17, 0x0, 0x0),
+    #     "type": EntranceGroups.DUNGEON_ENTRANCE,
+    #     "direction": EntranceGroups.INSIDE,
+    #     "island": EntranceGroups.NONE
+    # }
 
 
 }

--- a/worlds/tloz_st/data/Items.py
+++ b/worlds/tloz_st/data/Items.py
@@ -585,6 +585,7 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'value': 0x20,
         'item_groups': ["Rail Items", "Desert Tracks", "Misc Tracks", "Major Sand Tracks", "Tracks: Sand Realm"],
         "id": 62,
+        "model": "Ocean Glyph"
     },
     "Fire Realm Sand Portal Tracks": {
         'classification': ItemClassification.progression,

--- a/worlds/tloz_st/data/Items.py
+++ b/worlds/tloz_st/data/Items.py
@@ -350,7 +350,7 @@ ITEMS_DATA: dict[str, dict[str, Any]] = {
         'address': STAddr.adv_flags_1,
         'value': 0x80,
         'item_groups': ["Glyphs", "Rail Items", "Forest Tracks", "Major Forest Tracks", "Tracks: Forest Glyph"],
-        'model': "Forest Glyph 2",
+        'model': "Forest Glyph",
         "reload_entrances": [0x2F00], 
         "id": 38,
     },

--- a/worlds/tloz_st/data/Locations.py
+++ b/worlds/tloz_st/data/Locations.py
@@ -934,7 +934,8 @@ LOCATIONS_DATA = {
         'dungeon': "ToS",
         "tos_section": 6,
         "x_max": -80000,
-        "z_min": 40000
+        "z_min": 40000,
+        "delay_pickup": ["ToS 28F Stalfos"]
     },
     "ToS 28F E Raised Chest": {
         "stage_id": 0x13,
@@ -946,7 +947,8 @@ LOCATIONS_DATA = {
         "tos_section": 6,
         "x_max": -20000,
         "x_min": -40000,
-        "z_min": 25000
+        "z_min": 25000,
+        "delay_pickup": ["ToS 28F Stalfos"]
     },
     "ToS 29F SE Chest": {
         "stage_id": 0x13,
@@ -4214,6 +4216,14 @@ LOCATIONS_DATA |= {
         "x_max": -45000,
         "z_max": -55000,
         "conditional": True
+    },
+    "ToS 28F Stalfos": {  # Dummy location for stalfos treasure drop conflict
+        "stage_id": 0x13,
+        "room_id": 0x20,
+        "region_id": "mtt 2f right",
+        "vanilla_item": "Treasure: Stalfos Skull",
+        "conditional": True,
+        "x_max": -20000,
     },
 
 }

--- a/worlds/tloz_st/data/Locations.py
+++ b/worlds/tloz_st/data/Locations.py
@@ -950,7 +950,7 @@ LOCATIONS_DATA = {
         "z_min": 25000,
         "delay_pickup": ["ToS 28F Stalfos"]
     },
-    "ToS 29F SE Chest": {
+    "ToS 29F SE Eyes in the Dark Chest": {
         "stage_id": 0x13,
         "room_id": 0x1F,
         "region_id": "tos 29f se",
@@ -959,7 +959,8 @@ LOCATIONS_DATA = {
         'dungeon': "ToS",
         "tos_section": 6,
         "x_min": 80000,
-        "z_min": 20000
+        "z_min": 20000,
+        "delay_pickup": ["ToS 29F SE Extinguish Torches Chest"]
     },
     "ToS 30F SE Wrecker Chest": {
         "stage_id": 0x13,
@@ -2674,6 +2675,7 @@ LOCATIONS_DATA = {
         "vanilla_item": ITEM_GROUPS["Uncommon Treasures"],
         "region_id": "dt b1 damage",
         "dungeon": "Desert Temple",
+        "delay_pickup": ["Desert Temple B1 Stalfos"]
     },
     "Desert Temple B1 NW Buried Rupee": {
         "stage_id": 0x1D,
@@ -4224,6 +4226,26 @@ LOCATIONS_DATA |= {
         "vanilla_item": "Treasure: Stalfos Skull",
         "conditional": True,
         "x_max": -20000,
+    },
+    "ToS 29F SE Extinguish Torches Chest": {
+        "stage_id": 0x13,
+        "room_id": 0x1F,
+        "region_id": "tos 29f se",
+        "vanilla_item": ITEM_GROUPS["Rare Treasures"],
+        'dungeon': "ToS",
+        "tos_section": 6,
+        "x_min": 80000,
+        "z_min": 20000,
+        "delay_pickup": ["ToS 29F SE Eyes in the Dark Chest"]
+    },
+    "Desert Temple B1 Stalfos": {
+        "stage_id": 0x1D,
+        "room_id": 0x3,
+        "x_max": -75000,
+        "z_min": 45000,
+        "vanilla_item": "Treasure: Stalfos Skull",
+        "region_id": "dt b1 damage",
+        "conditional": True
     },
 
 }

--- a/worlds/tloz_st/tracker/locations/tos_singles.json
+++ b/worlds/tloz_st/tracker/locations/tos_singles.json
@@ -72,7 +72,8 @@
       {"name": "ToS 30F W Chest"},
       {"name": "ToS 28F W Raised Chest"},
       {"name": "ToS 28F E Raised Chest"},
-      {"name": "ToS 29F SE Chest"},
+      {"name": "ToS 29F SE Eyes in the Dark Chest"},
+      {"name": "ToS 29F SE Extinguish Torches Chest"},
       {"name": "ToS 30F SE Wrecker Chest"},
       {"name": "ToS 24F Final Chest"}], "map_locations":[{"map": "Overview", "x": 512, "y": 308}]},
   {"name": "ToS 6 Events", "sections": [{"name": "EVENT: Reach ToS 24F"},{"name": "GOAL: Reach ToS 24F"}], "map_locations":[{"map": "Overview", "x": 528, "y": 308}]}


### PR DESCRIPTION
- Added missing location: `ToS 29F SE Extinguish Torches Chest`
- Added option for generic multiworld item models, with options force gems, letters and rupees
- Fixed /goal crash with a dungeon goal
- Fixed crash from getting tear of light in certain circumstances
- Prevented stalfos skulls from triggering location on ToS 28F and Desert Temple B1
- Changed default keyring option to no_keyrings
- Fixed Anouki Chief not giving location if visited Icy Spring
- Prevented small keys from underflowing
- Preventing warp to start from resetting the train after a client restart
- Fixed the boss key locations in Tower of Spirits
- Forest Glyph now displays the correct model
- Added missing model for Sand Realm Tracks