### PR TITLE
ST AP v7.7

### DIFF
--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -3,7 +3,7 @@ from .DSZeldaClient.DSZeldaClient import *
 from .DSZeldaClient.subclasses import storage_key, split_bits
 from .data.Addresses import STAddr
 from .data.Items import ITEMS
-from .data.Entrances import ENTRANCES
+from .data.Entrances import ENTRANCES, boss_events
 from settings import get_settings
 from typing import Literal
 
@@ -251,7 +251,7 @@ class SpiritTracksClient(DSZeldaClient):
             has_locs = sum([1 for loc in ctx.checked_locations if loc in dungeon_locs])
             logger.info(
                 f"You need to complete {specific}dungeons to enter the dark realm. Progress: {has_locs}/{slot_data['dungeons_required']}")
-            if slot_data["dungeon_hints"]:
+            if slot_data.get("dungeon_hints", 1):
                 dungeons_locs = [self.location_id_to_name[i] for i in slot_data["required_dungeons"]]
                 logger.info(f"Your dungeons: {dungeons_locs}")
         if slot_data["dark_realm_access"] in [2, 3]:

--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -989,6 +989,7 @@ class SpiritTracksClient(DSZeldaClient):
                          or max(0, (self.item_count(ctx, "Big Tear of Light (Progressive)") - big_prog_sub) * 3)
                          or max(0, self.item_count(ctx, "Tear of Light (Progressive)") - big_prog_sub * 3)
                          )
+            set_tears = min(set_tears, 3)
             print(f"Setting tears for section {section} tears {set_tears}")
         else:
             print(f"Setting tears {set_tears}")

--- a/worlds/tloz_st/Client.py
+++ b/worlds/tloz_st/Client.py
@@ -918,12 +918,14 @@ class SpiritTracksClient(DSZeldaClient):
     async def process_deathlink(self, ctx: "BizHawkClientContext", is_dead, stage, read_result):
         if read_result[STAddr.menu] and stage >= 0x13:
             return
-        # if stage < 0x13:  # deaths work badly on train
-        #     return
+        dead_health = 0
+        if stage < 0x13:  # deaths work badly on train
+            dead_health = 1
 
         if ctx.last_death_link > self.last_deathlink and not is_dead:
             # A death was received from another player, make our player die as well
-            await self.health_address.overwrite(ctx, 0)
+
+            await self.health_address.overwrite(ctx, dead_health)
 
             self.is_expecting_received_death = True
             self.last_deathlink = ctx.last_death_link

--- a/worlds/tloz_st/Util.py
+++ b/worlds/tloz_st/Util.py
@@ -71,11 +71,11 @@ def _check_slot_data(ctx, data):
     if "has_slot_data" in data:
         for slot, value, *args in data["has_slot_data"]:
             slot_value = ctx.slot_data.get(slot, None)
-            # print(f"\t\tTesting slot {slot_value} {type(slot_value)} {value}")
-            if type(value) is list:
+            # print(f"\t\tTesting slot {data['name']} {slot_value} {type(slot_value)} {value}")
+            if isinstance(value, list):
                 if slot_value not in value:
                     return False
-            elif type(slot_value) is list:
+            elif isinstance(slot_value, list):
                 if args and args[0] == "not":
                     if value in slot_value:
                         return False

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -18,7 +18,7 @@ from .data.ModelLookups import all_lookups
 from .data.Regions import REGIONS
 from .data.LogicPredicates import *
 from .data.Entrances import (ENTRANCES, entrance_id_to_region, entrance_id_to_entrance,
-                             location_event_lookup, goal_event_lookup)
+                             location_event_lookup, goal_event_lookup, boss_events)
 from entrance_rando import disconnect_entrance_for_randomization
 
 from .Client import SpiritTracksClient  # Unused, but required to register with BizHawkClient
@@ -1449,7 +1449,7 @@ class SpiritTracksWorld(WorldParent):
     def fill_slot_data(self) -> dict:
         options = ["goal", "compass_shard_count",
                    "logic", "cannon_logic",
-                   "exclude_dungeons", "exclude_sections", "require_specific_dungeons",
+                   "exclude_dungeons", "exclude_sections", "require_specific_dungeons", "dungeon_hints",
                    "keysanity", "randomize_boss_keys",
                    "big_keyrings",
                    "randomize_minigames", "minigame_hints",
@@ -1517,3 +1517,7 @@ class SpiritTracksWorld(WorldParent):
 
                     if exit_name == "EVENT: Bring Ice to Kagoron":
                         self.get_region("goron village").connect(self.get_region("goron ice"))
+
+                    if exit_name in boss_events:
+                        print(f"Globally connecting outset village => {_exit.parent_region}")
+                        self.get_region("outset village").connect(_exit.parent_region)

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -549,8 +549,6 @@ class SpiritTracksWorld(WorldParent):
                     if self.options.randomize_cargo.value not in values:
                         return False
                 return True
-        if location_name == "Goron Village Get Wagon":
-            return self.options.randomize_cargo.value
         return False
 
     def create_events(self):
@@ -1284,7 +1282,6 @@ class SpiritTracksWorld(WorldParent):
             confined_dungeon_items.extend([item for item in items if item.name in ITEM_GROUPS["Tears of Light"]])
 
         # Filter out starting inventory items, borrowed from EternalCode's Minish cap implementation
-        print(f"Pre fill items (pre start items) {confined_dungeon_items}")
         start_inv = self.options.start_inventory_from_pool.value
         known_start_inv = {}
         def keep_item(s):
@@ -1296,7 +1293,7 @@ class SpiritTracksWorld(WorldParent):
             items.remove(item)
 
         self.pre_fill_items.extend(confined_dungeon_items)
-        print(f"Pre fill items {self.pre_fill_items}")
+        # print(f"Pre fill items {self.pre_fill_items}")
 
     def pre_fill_tos_sections(self):
         for section in range(1, 7):

--- a/worlds/tloz_st/__init__.py
+++ b/worlds/tloz_st/__init__.py
@@ -243,7 +243,7 @@ class SpiritTracksWorld(WorldParent):
                 tos_summit_boss in self.required_dungeons
             ]):
                 self.options.spirit_weapons.value = 0
-                print(f"ToS Summit needs final spirit weapon. Turning off spirit weapons.")
+                # print(f"ToS Summit needs final spirit weapon. Turning off spirit weapons.")
 
             if self.options.starting_train == "random_train":
                 self.options.starting_train.value = self.random.randint(0, 7)
@@ -1272,6 +1272,7 @@ class SpiritTracksWorld(WorldParent):
     def filter_confined_dungeon_items_from_pool(self, items: List[SpiritTracksItem]):
         confined_dungeon_items = []
 
+
         # Confine small keys and boss key to own dungeon if option is enabled
         if self.options.keysanity in ["in_own_dungeon", "in_own_section"]:
             confined_dungeon_items.extend([item for item in items if item.name.startswith("Small Key") or item.name.startswith("Keyring (")])
@@ -1282,10 +1283,20 @@ class SpiritTracksWorld(WorldParent):
         if self.options.randomize_tears in ["in_own_section", "in_tos"]:
             confined_dungeon_items.extend([item for item in items if item.name in ITEM_GROUPS["Tears of Light"]])
 
+        # Filter out starting inventory items, borrowed from EternalCode's Minish cap implementation
+        print(f"Pre fill items (pre start items) {confined_dungeon_items}")
+        start_inv = self.options.start_inventory_from_pool.value
+        known_start_inv = {}
+        def keep_item(s):
+            known_start_inv[s] = known_start_inv.get(s, 0) + 1
+            return s not in start_inv or known_start_inv[s] > start_inv[s]
+        confined_dungeon_items = [i for i in confined_dungeon_items if keep_item(i.name)]
+
         for item in confined_dungeon_items:
             items.remove(item)
+
         self.pre_fill_items.extend(confined_dungeon_items)
-        # print(f"Pre fill items {self.pre_fill_items}")
+        print(f"Pre fill items {self.pre_fill_items}")
 
     def pre_fill_tos_sections(self):
         for section in range(1, 7):

--- a/worlds/tloz_st/data/DynamicFlags.py
+++ b/worlds/tloz_st/data/DynamicFlags.py
@@ -859,7 +859,14 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "has_items": [("Spirit Flute", 1)],
         "not_has_locations": ["Snowfall Sanctuary Song of Restoration"],
         "has_slot_data": [("randomize_minigames", [1, 2, 3, 4, 5, 6])],
-        "unset_if_true": [(STAddr.adv_flags_1, 6)]
+        "unset_if_true": [(STAddr.adv_flags_1, 0x6)]
+    },
+    "Steem has played duet": {
+        "on_scenes": [0x3102],
+        "has_locations": ["Snowfall Sanctuary Song of Restoration"],
+        "has_slot_data": [("randomize_minigames", [1, 2, 3, 4, 5, 6])],
+        "set_if_true": [(STAddr.adv_flags_1, 0x2)],
+        "unset_if_true": [(STAddr.adv_flags_1, 0x4)]
     },
     "Snow sanc remove vessel": {
         "on_scenes": [0x3102],
@@ -873,7 +880,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
     },
     "Always remove btt in snow sanc room": {  # and ocean restoration
         "on_scenes": [0x3102],
-        "unset_if_true": [(STAddr.rail_restorations, 0x4), (STAddr.adv_flags_1, 0x4)],
+        "unset_if_true": [(STAddr.rail_restorations, 0x4)],
         "reset_flags": ["Snow sanc Reset BTT not has", "Snow sanc Reset BTT"]
     },
     "Snow sanc Reset BTT not has": {
@@ -1874,6 +1881,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "on_scenes": [0x3200],
         "has_items": [("Passenger: Carben", 1)],
         "not_has_locations": ["Island Sanctuary Carben's Force Gem"],
+        "has_slot_data": [("randomize_passengers", [2, 3])],
         "set_if_true": [(STAddr.adv_flags_9, 0x10)],
         "unset_if_true": [(STAddr.adv_flags_9, 0x20)],  # Prevent invisible carben
         "overwrite_if_true": [(STAddr.passenger_goal, 0x32),

--- a/worlds/tloz_st/data/DynamicFlags.py
+++ b/worlds/tloz_st/data/DynamicFlags.py
@@ -2224,8 +2224,15 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
         "on_scenes": [0x2c00],
         "not_has_locations": ["Papuzia Village Song Statue"],
         "has_items": [("Song of Discovery", 1)],
-        "unset_if_true": [(STAddr.songs, 0x4), (STAddr.adv_flags_9, 0x10)],
+        "unset_if_true": [(STAddr.songs, 0x4)], # (STAddr.adv_flags_9, 0x10)],
         "set_if_true": [(STAddr.adv_flags_a, 0xA0)]
+    },
+    "Prevent carben crash no passengers": {
+        "on_scenes": [0x2c00],
+        "not_has_locations": ["Papuzia Village Song Statue"],
+        "has_items": [("Song of Discovery", 1)],
+        "has_slot_data": [("randomize_passengers", 0)],
+        "unset_if_true": [(STAddr.adv_flags_9, 0x30)],
     },
     "Papuzia default reset SoB": {
         "on_scenes": [0x2c00],
@@ -2238,7 +2245,7 @@ DYNAMIC_FLAGS: dict[str, dict[str, Any]] = {
     "Papuzia allow song of birds": {
         "on_scenes": [0x2c00],
         "not_has_locations": ["Papuzia Village Song Statue"],
-        "has_items": [("Song of Birds", 1)],
+        "has_items": [("Song of Birds", 1), ("Song of Discovery", 0)],
         "set_if_true": [(STAddr.songs, 4)],
     },
     "Papuzia can buy vessel": {

--- a/worlds/tloz_st/data/Entrances.py
+++ b/worlds/tloz_st/data/Entrances.py
@@ -744,6 +744,7 @@ location_event_lookup = {"Wooded Temple Dungeon Reward": "EVENT: Defeat Stagnox"
                          "Desert Temple Dungeon Reward": "EVENT: Defeat Skeldritch",
                          "Castle Town Take 'em All On Level 3": "EVENT: Complete Take 'em All On 3",
                          "Lost at Sea Final Chest": "EVENT: Complete Lost at Sea Dungeon"}
+boss_events = set(location_event_lookup.values())
 goal_event_lookup =     {0: "GOAL: Defeat Stagnox",
                          1: "GOAL: Defeat Fraaz",
                          2: "GOAL: Defeat Cactops",

--- a/worlds/tloz_st/data/Locations.py
+++ b/worlds/tloz_st/data/Locations.py
@@ -1191,7 +1191,7 @@ LOCATIONS_DATA = {
     },
     "Wooded Temple 3F SE Chest": {
         "region_id": "wt 3f se chest",
-        "vanilla_item": "Red Rupee (20)",
+        "vanilla_item": {"Red Rupee (20)"} | ITEM_GROUPS["Uncommon Treasures"],
         "stage_id": 0x19,
         "room_id": 2,
         "x_min": 42646,
@@ -1995,6 +1995,7 @@ LOCATIONS_DATA = {
         "require_item": ["Bow (Progressive)"],
         "address": STAddr.adv_flags_56,
         "value": 0x10,
+        "delay_reset": True,
         "location_groups": ["Pirate Hideout", "Pirate Hideout Minigame",
                             "Pirate Hideout Easy", "Pirate Hideout Minigame Easy"],
         "slot_data": [("randomize_minigames", [1, 3, 4])],
@@ -2009,6 +2010,7 @@ LOCATIONS_DATA = {
         "minigame": [2, 3, 4],
         "require_item": ["Bow (Progressive)]"],  # Pirate hideout gives a free bow, decide if we want that or not.
         "address": STAddr.adv_flags_56,
+        "delay_reset": True,
         "value": 0x20,
         "location_groups": ["Pirate Hideout", "Pirate Hideout Minigame",
                             "Pirate Hideout Hard", "Pirate Hideout Minigame Hard"],

--- a/worlds/tloz_st/data/Locations.py
+++ b/worlds/tloz_st/data/Locations.py
@@ -2197,7 +2197,7 @@ LOCATIONS_DATA = {
         "item_override": "Nothing!",
         "slot_data": [("randomize_cargo", [1, 2, 3])],
         "conditional": True,
-        "location_groups": ["Goron Village"],
+        "location_groups": ["Goron Village", "Cargo Locations"],
         "no_model": True
     },
     "Goron Village Chest Above Elder's House": {
@@ -4293,7 +4293,7 @@ LOCATION_GROUPS["Mountain Rabbits"] = LOCATION_GROUPS["Total Mountain Rabbits"] 
 LOCATION_GROUPS["Sand Rabbits"] = LOCATION_GROUPS["Total Sand Rabbits"] | LOCATION_GROUPS["Unique Sand Rabbits"]
 LOCATION_GROUPS["Rabbit Locations"] = LOCATION_GROUPS["Unique Rabbits"] | LOCATION_GROUPS["Total Rabbits"]
 LOCATION_GROUPS["Passenger Locations"] = LOCATION_GROUPS["Pick Up Passengers"] | LOCATION_GROUPS["Deliver Passengers"] | LOCATION_GROUPS["Misc Passengers"]
-LOCATION_GROUPS["Cargo Locations"] = LOCATION_GROUPS["Buy Cargo"] | LOCATION_GROUPS["Deliver Cargo"]
+LOCATION_GROUPS["Cargo Locations"] |= LOCATION_GROUPS["Buy Cargo"] | LOCATION_GROUPS["Deliver Cargo"]
 
 # print(f"Location Groups:")
 # for group, locs in LOCATION_GROUPS.items():

--- a/worlds/tloz_st/test/bases.py
+++ b/worlds/tloz_st/test/bases.py
@@ -16,9 +16,9 @@ class TestGeneration(WorldTestBase):
         "dungeons_required": 12,
         "tos_dungeon_options": "all_sections",
 
-        "randomize_tears": "vanilla_items",
-        "tear_size": "small",
-        "tear_sections": "progressive",
+        "randomize_tears": "in_own_section",
+        "tear_size": "large",
+        "tear_sections": "unique_sections",
         "spirit_weapons": "final_tear",
 
         "keysanity": "vanilla",
@@ -42,5 +42,8 @@ class TestGeneration(WorldTestBase):
         "start_with_train": True,
         "cannon_logic": "open_train",
         "portal_behavior": "always_open",
+        "start_inventory_from_pool": {
+            "Big Tear of Light (ToS 1)": 1
+        }
 
     }

--- a/worlds/tloz_st/test/bases.py
+++ b/worlds/tloz_st/test/bases.py
@@ -32,7 +32,7 @@ class TestGeneration(WorldTestBase):
         "excess_random_treasure": "nothing",
         "logic": "normal",
         "randomize_passengers": "randomize",
-        "randomize_cargo": "no_cargo",
+        "randomize_cargo": "randomize",
         "randomize_stamps": "randomize",
         "stamp_pack_sizes": 1,
         "randomize_minigames": "hard",


### PR DESCRIPTION
- `Goron Village Get Wagon` is no longer in pool when randomize cargo is off
- Starting items from pool no longer duplicate if they're in a pre-fill pool
- Carben no longer boards train with no passengers option
- Receiving a deathlink on train sets your health to 1 instead of 0, preventing softlocks, but still making you die in one hit.
- Steem no loger make you play his song again on repeat visits
- Added delay reset to pirate hideout rewards
- Fixed vanilla item for `Wooded Temple 3f SE Chest`
- Fixed client crash from `/goal` command
- UT dungeon events light up on collecting even if the event is out of logic